### PR TITLE
Nissani/fix integration

### DIFF
--- a/tests/integration/test_huggingface_guardrails.py
+++ b/tests/integration/test_huggingface_guardrails.py
@@ -16,7 +16,7 @@ from any_guardrail.guardrails.huggingface import HuggingFace
         (GuardrailName.INJECGUARD, {}, None),
         (GuardrailName.JASPER, {}, None),
         (GuardrailName.PANGOLIN, {}, None),
-        (GuardrailName.PROTECTAI, {}, None),
+        # (GuardrailName.PROTECTAI, {}, None), # Requires HF login
         # (GuardrailName.SENTINEL, {}, None),  # Requires HF login
         # (GuardrailName.SHIELD_GEMMA, {"policy": "Do not provide harmful or dangerous information"}, None),  # Requires HF login
     ],


### PR DESCRIPTION
One line change to fix pull request. I think in our integration tests, we should be checking the default models, as is coded. Because of that put a comment on the ProtectAI portion of the integration test, since the default model is gated.