### PR TITLE
refactor: Import guardrail classes in corresponding `__init__.py`.

### DIFF
--- a/docs/api/guardrails/any_llm.md
+++ b/docs/api/guardrails/any_llm.md
@@ -1,1 +1,1 @@
-::: any_guardrail.guardrails.any_llm.any_llm
+::: any_guardrail.guardrails.any_llm

--- a/docs/api/guardrails/deepset.md
+++ b/docs/api/guardrails/deepset.md
@@ -1,1 +1,1 @@
-::: any_guardrail.guardrails.deepset.deepset
+::: any_guardrail.guardrails.deepset

--- a/docs/api/guardrails/duo_guard.md
+++ b/docs/api/guardrails/duo_guard.md
@@ -1,1 +1,1 @@
-::: any_guardrail.guardrails.duo_guard.duo_guard
+::: any_guardrail.guardrails.duo_guard

--- a/docs/api/guardrails/flowjudge.md
+++ b/docs/api/guardrails/flowjudge.md
@@ -1,1 +1,1 @@
-::: any_guardrail.guardrails.flowjudge.flowjudge
+::: any_guardrail.guardrails.flowjudge

--- a/docs/api/guardrails/glider.md
+++ b/docs/api/guardrails/glider.md
@@ -1,1 +1,1 @@
-::: any_guardrail.guardrails.glider.glider
+::: any_guardrail.guardrails.glider

--- a/docs/api/guardrails/harm_guard.md
+++ b/docs/api/guardrails/harm_guard.md
@@ -1,1 +1,1 @@
-::: any_guardrail.guardrails.harm_guard.harm_guard
+::: any_guardrail.guardrails.harm_guard

--- a/docs/api/guardrails/injec_guard.md
+++ b/docs/api/guardrails/injec_guard.md
@@ -1,1 +1,1 @@
-::: any_guardrail.guardrails.injec_guard.injec_guard
+::: any_guardrail.guardrails.injec_guard

--- a/docs/api/guardrails/jasper.md
+++ b/docs/api/guardrails/jasper.md
@@ -1,1 +1,1 @@
-::: any_guardrail.guardrails.jasper.jasper
+::: any_guardrail.guardrails.jasper

--- a/docs/api/guardrails/pangolin.md
+++ b/docs/api/guardrails/pangolin.md
@@ -1,1 +1,1 @@
-::: any_guardrail.guardrails.pangolin.pangolin
+::: any_guardrail.guardrails.pangolin

--- a/docs/api/guardrails/protectai.md
+++ b/docs/api/guardrails/protectai.md
@@ -1,1 +1,1 @@
-::: any_guardrail.guardrails.protectai.protectai
+::: any_guardrail.guardrails.protectai

--- a/docs/api/guardrails/sentinel.md
+++ b/docs/api/guardrails/sentinel.md
@@ -1,1 +1,1 @@
-::: any_guardrail.guardrails.sentinel.sentinel
+::: any_guardrail.guardrails.sentinel

--- a/docs/api/guardrails/shield_gemma.md
+++ b/docs/api/guardrails/shield_gemma.md
@@ -1,1 +1,1 @@
-::: any_guardrail.guardrails.shield_gemma.shield_gemma
+::: any_guardrail.guardrails.shield_gemma

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Refer to the [Quickstart](./quickstart.md) for instructions on installation and 
 
 ### Guardrails
 
-Refer to [Guardrails](./api/guardrails) for the parameters for each guardrail.
+Refer to [Guardrails](./api/guardrails/index.md) for the parameters for each guardrail.
 
 Refer to [AnyGuardrail](./api/any_guardrail.md) for how to use the `AnyGuardrail` object.
 

--- a/src/any_guardrail/api.py
+++ b/src/any_guardrail/api.py
@@ -46,7 +46,7 @@ class AnyGuardrail:
     @classmethod
     def _get_guardrail_class(cls, guardrail_name: GuardrailName) -> type[Guardrail]:
         guardrail_module_name = f"{guardrail_name.value}"
-        module_path = f"any_guardrail.guardrails.{guardrail_module_name}.{guardrail_module_name}"
+        module_path = f"any_guardrail.guardrails.{guardrail_module_name}"
 
         module = importlib.import_module(module_path)
         parts = re.split(r"[^A-Za-z0-9]+", guardrail_module_name)

--- a/src/any_guardrail/guardrails/any_llm/__init__.py
+++ b/src/any_guardrail/guardrails/any_llm/__init__.py
@@ -1,0 +1,3 @@
+from .any_llm import AnyLlm
+
+__all__ = ["AnyLlm"]

--- a/src/any_guardrail/guardrails/deepset/__init__.py
+++ b/src/any_guardrail/guardrails/deepset/__init__.py
@@ -1,0 +1,3 @@
+from .deepset import Deepset
+
+__all__ = ["Deepset"]

--- a/src/any_guardrail/guardrails/duo_guard/__init__.py
+++ b/src/any_guardrail/guardrails/duo_guard/__init__.py
@@ -1,0 +1,3 @@
+from .duo_guard import DuoGuard
+
+__all__ = ["DuoGuard"]

--- a/src/any_guardrail/guardrails/flowjudge/__init__.py
+++ b/src/any_guardrail/guardrails/flowjudge/__init__.py
@@ -1,0 +1,3 @@
+from .flowjudge import Flowjudge
+
+__all__ = ["Flowjudge"]

--- a/src/any_guardrail/guardrails/glider/__init__.py
+++ b/src/any_guardrail/guardrails/glider/__init__.py
@@ -1,0 +1,3 @@
+from .glider import Glider
+
+__all__ = ["Glider"]

--- a/src/any_guardrail/guardrails/harm_guard/__init__.py
+++ b/src/any_guardrail/guardrails/harm_guard/__init__.py
@@ -1,0 +1,3 @@
+from .harm_guard import HarmGuard
+
+__all__ = ["HarmGuard"]

--- a/src/any_guardrail/guardrails/injec_guard/__init__.py
+++ b/src/any_guardrail/guardrails/injec_guard/__init__.py
@@ -1,0 +1,3 @@
+from .injec_guard import InjecGuard
+
+__all__ = ["InjecGuard"]

--- a/src/any_guardrail/guardrails/jasper/__init__.py
+++ b/src/any_guardrail/guardrails/jasper/__init__.py
@@ -1,0 +1,3 @@
+from .jasper import Jasper
+
+__all__ = ["Jasper"]

--- a/src/any_guardrail/guardrails/pangolin/__init__.py
+++ b/src/any_guardrail/guardrails/pangolin/__init__.py
@@ -1,0 +1,3 @@
+from .pangolin import Pangolin
+
+__all__ = ["Pangolin"]

--- a/src/any_guardrail/guardrails/protectai/__init__.py
+++ b/src/any_guardrail/guardrails/protectai/__init__.py
@@ -1,0 +1,3 @@
+from .protectai import Protectai
+
+__all__ = ["Protectai"]

--- a/src/any_guardrail/guardrails/sentinel/__init__.py
+++ b/src/any_guardrail/guardrails/sentinel/__init__.py
@@ -1,0 +1,3 @@
+from .sentinel import Sentinel
+
+__all__ = ["Sentinel"]

--- a/src/any_guardrail/guardrails/shield_gemma/__init__.py
+++ b/src/any_guardrail/guardrails/shield_gemma/__init__.py
@@ -1,0 +1,3 @@
+from .shield_gemma import ShieldGemma
+
+__all__ = ["ShieldGemma"]


### PR DESCRIPTION
Sorry, I missed the review of https://github.com/mozilla-ai/any-guardrail/pull/54 .

This way, the code is still organizer under the same dir structure but the imports don't need to include duplciated `guardrail_name.guardrail_name`.