### PR TITLE
chore: Drop cache.

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -21,15 +21,6 @@ jobs:
           python-version: 3.13
           activate-environment: true
 
-      - name: Cache HuggingFace models
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/huggingface
-          key: ${{ runner.os }}-hf-cache-${{ hashFiles('**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-hf-cache-
-
       - name: Install dependencies
         run: |
           uv sync --group tests --extra all


### PR DESCRIPTION
It seems that the cache exceeds the maximum size supported in GitHub or something, so we end up just wasting time trying to build the cache but it never gets pushed (and thus, never reused).

<img width="1446" height="460" alt="image" src="https://github.com/user-attachments/assets/addaffc3-0bf0-4891-94c3-3ece910819f8" />
