### PR TITLE
tests: Add test_glider_postprocessing.

### DIFF
--- a/tests/unit/test_unit_glider_guardrail.py
+++ b/tests/unit/test_unit_glider_guardrail.py
@@ -1,0 +1,25 @@
+from unittest.mock import patch
+
+import pytest
+
+from any_guardrail import GuardrailOutput
+from any_guardrail.guardrails.glider import Glider
+
+
+@pytest.mark.parametrize(
+    ("model_outputs", "expected_score"),
+    [
+        ("<score>\n0.9\n</score>", None),
+        ("<score>\nnot_a_number\n</score>", None),
+        ("bad_format", None),
+        ("<score>\n8\n</score>", 8),
+    ],
+)
+def test_glider_postprocessing(model_outputs: str, expected_score: float | None) -> None:
+    with patch("any_guardrail.guardrails.glider.glider.Glider._load_model"):
+        glider = Glider("foo", "bar")
+
+        result = glider._post_processing(model_outputs)
+
+        assert isinstance(result, GuardrailOutput)
+        assert result.score == expected_score


### PR DESCRIPTION
@dni138 this is an example of what I meant with adding a regression test in https://github.com/mozilla-ai/any-guardrail/pull/69

Because we have the logic isolated in methods, we don't necessarily need an integration test (that runs the actual model) but can instead define a simple unit test.