### PR TITLE
Fix where we install mypy from.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,10 +31,11 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: "uv run mypy"
-        args: []
+        entry: "uv run mypy src tests"
         language: system
         types: [python]
+        pass_filenames: false
+        require_serial: true
         verbose: true
 
   - repo: https://github.com/codespell-project/codespell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ docs = [
 lint = [
   "pre-commit==4.5.1",
   "pre-commit-uv==4.2.1",
-  "mypy",
+  "mypy @ git+https://github.com/python/mypy.git",
 ]
 
 tests = [


### PR DESCRIPTION
# Pull Request

## Description

mypy was pointing to a different version than what was loaded in the CI. Changed to point to the main branch of mypy.

## Type of Change
<!-- Mark the relevant option with an [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Dependency update
- [ ] CI/CD or tooling change

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

Linter was breaking in github CI.

## Changes Made
<!-- Describe the changes in detail -->

Updated pyproject.toml to point to the main branch of mypy.
