### PR TITLE
feat: add device parameter to HuggingFaceProvider

### DIFF
--- a/src/any_guardrail/guardrails/alinia/alinia.py
+++ b/src/any_guardrail/guardrails/alinia/alinia.py
@@ -112,8 +112,8 @@ class Alinia(Guardrail[bool, dict[str, dict[str, float | bool | str]], dict[str,
 
         return initial_json
 
-    def _inference(self, params: AnyDict) -> requests.Response:  # type: ignore[name-defined]
-        response = requests.post(  # type: ignore[attr-defined, no-untyped-call]
+    def _inference(self, params: AnyDict) -> requests.Response:
+        response = requests.post(
             self.endpoint,
             headers={"Authorization": f"Bearer {self.api_key}"},
             json=params,
@@ -125,7 +125,7 @@ class Alinia(Guardrail[bool, dict[str, dict[str, float | bool | str]], dict[str,
 
     def _post_processing(
         self,
-        response: requests.Response,  # type: ignore[name-defined]
+        response: requests.Response,
     ) -> GuardrailOutput[bool, dict[str, dict[str, float | bool | str]], dict[str, dict[str, float]]]:
         explanation = response.json()
         valid = not explanation.get("result").get("flagged")

--- a/src/any_guardrail/guardrails/granite_guardian/granite_guardian.py
+++ b/src/any_guardrail/guardrails/granite_guardian/granite_guardian.py
@@ -273,6 +273,9 @@ class GraniteGuardian(ThreeStageGuardrail[GraniteGuardianPreprocessData, Granite
         model_inputs = self.provider.tokenizer.apply_chat_template(  # type: ignore[attr-defined]
             messages, **template_kwargs, **kwargs
         )
+        device = getattr(self.provider, "device", None)
+        if device is not None and hasattr(model_inputs, "to"):
+            model_inputs = model_inputs.to(device)
         return GuardrailPreprocessOutput(data=model_inputs)
 
     def _inference(

--- a/src/any_guardrail/guardrails/harm_guard/harm_guard.py
+++ b/src/any_guardrail/guardrails/harm_guard/harm_guard.py
@@ -66,13 +66,16 @@ class HarmGuard(StandardGuardrail):
             tokenized = self.provider.tokenizer(input_text, return_tensors="pt")  # type: ignore[attr-defined]
         else:
             tokenized = self.provider.tokenizer(input_text, output_text, return_tensors="pt")  # type: ignore[attr-defined]
+        device = getattr(self.provider, "device", None)
+        if device is not None:
+            tokenized = tokenized.to(device)
         return GuardrailPreprocessOutput(data=tokenized)
 
     def _inference(self, model_inputs: StandardPreprocessOutput) -> StandardInferenceOutput:
         return self.provider.infer(model_inputs)
 
     def _post_processing(self, model_outputs: StandardInferenceOutput) -> BinaryScoreOutput:
-        logits = model_outputs.data["logits"][0].numpy()
+        logits = model_outputs.data["logits"][0].cpu().numpy()
         scores = _softmax(logits)  # type: ignore[no-untyped-call]
         final_score = float(scores[1])  # scores[1] is the unsafe probability
         return GuardrailOutput(valid=final_score < self.threshold, score=final_score)

--- a/src/any_guardrail/guardrails/llama_guard/llama_guard.py
+++ b/src/any_guardrail/guardrails/llama_guard/llama_guard.py
@@ -113,6 +113,9 @@ class LlamaGuard(ThreeStageGuardrail[LlamaGuardPreprocessData, LlamaGuardInferen
         self._cached_model_inputs = self.provider.tokenizer.apply_chat_template(  # type: ignore[attr-defined]
             conversation, **self.tokenizer_params, **kwargs
         )
+        device = getattr(self.provider, "device", None)
+        if device is not None and hasattr(self._cached_model_inputs, "to"):
+            self._cached_model_inputs = self._cached_model_inputs.to(device)
         return GuardrailPreprocessOutput(data=self._cached_model_inputs)
 
     def _inference(

--- a/src/any_guardrail/guardrails/shield_gemma/shield_gemma.py
+++ b/src/any_guardrail/guardrails/shield_gemma/shield_gemma.py
@@ -67,6 +67,9 @@ class ShieldGemma(StandardGuardrail):
     def _pre_processing(self, input_text: str) -> StandardPreprocessOutput:
         formatted_prompt = self.system_prompt.format(user_prompt=input_text, safety_policy=self.policy)
         tokenized = self.provider.tokenizer(formatted_prompt, return_tensors="pt")  # type: ignore[attr-defined]
+        device = getattr(self.provider, "device", None)
+        if device is not None:
+            tokenized = tokenized.to(device)
         return GuardrailPreprocessOutput(data=tokenized)
 
     def _inference(self, model_inputs: StandardPreprocessOutput) -> StandardInferenceOutput:

--- a/src/any_guardrail/guardrails/utils.py
+++ b/src/any_guardrail/guardrails/utils.py
@@ -44,7 +44,7 @@ def match_injection_label(
         GuardrailOutput with valid=True if content is safe, valid=False if injection detected.
 
     """
-    logits = model_outputs.data["logits"][0].numpy()
+    logits = model_outputs.data["logits"][0].cpu().numpy()
     scores = _softmax(logits)  # type: ignore[no-untyped-call]
     label = id2label[scores.argmax().item()]
     return GuardrailOutput(valid=label != injection_label, score=scores.max().item())

--- a/src/any_guardrail/providers/huggingface.py
+++ b/src/any_guardrail/providers/huggingface.py
@@ -29,6 +29,10 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
         tokenizer_class: The transformers tokenizer class to use. Defaults to AutoTokenizer.
         tokenizer_id: Override the tokenizer model ID (defaults to the same as model_id).
         trust_remote_code: Whether to trust remote code when loading models.
+        device: The torch device to load the model on (e.g., ``"cpu"``, ``"cuda"``,
+            ``"cuda:0"``, ``"mps"``). When ``None``, the model stays on the device
+            chosen by ``transformers`` (typically CPU). Tokenized inputs are moved
+            to this device automatically before inference.
 
     """
 
@@ -38,6 +42,7 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
         tokenizer_class: type | None = None,
         tokenizer_id: str | None = None,
         trust_remote_code: bool = False,
+        device: str | None = None,
     ) -> None:
         """Initialize the HuggingFace provider."""
         if MISSING_PACKAGES_ERROR is not None:
@@ -48,6 +53,7 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
         self.tokenizer_class = tokenizer_class or AutoTokenizer
         self.tokenizer_id = tokenizer_id
         self.trust_remote_code = trust_remote_code
+        self.device = device
         self.model: Any = None
         self.tokenizer: Any = None
 
@@ -64,6 +70,8 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
             load_kwargs["trust_remote_code"] = True
 
         self.model = self.model_class.from_pretrained(model_id, **load_kwargs, **kwargs)  # type: ignore[attr-defined]
+        if self.device is not None:
+            self.model = self.model.to(self.device)
         tokenizer_id = self.tokenizer_id or model_id
         self.tokenizer = self.tokenizer_class.from_pretrained(tokenizer_id, **load_kwargs)  # type: ignore[attr-defined]
 
@@ -79,6 +87,8 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
 
         """
         tokenized = self.tokenizer(input_text, return_tensors="pt", **kwargs)
+        if self.device is not None:
+            tokenized = tokenized.to(self.device)
         return GuardrailPreprocessOutput(data=tokenized)
 
     def infer(self, model_inputs: GuardrailPreprocessOutput[AnyDict]) -> GuardrailInferenceOutput[AnyDict]:

--- a/tests/unit/test_unit_huggingface_provider.py
+++ b/tests/unit/test_unit_huggingface_provider.py
@@ -1,0 +1,95 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from any_guardrail.providers.huggingface import HuggingFaceProvider
+
+
+def test_device_defaults_to_none() -> None:
+    """When no device is provided, the provider stores ``None`` and does not move anything."""
+    provider = HuggingFaceProvider()
+    assert provider.device is None
+
+
+def test_load_model_moves_model_to_device() -> None:
+    """When a device is configured, ``load_model`` moves the loaded model to that device."""
+    model = MagicMock()
+    moved_model = MagicMock()
+    model.to.return_value = moved_model
+    model_class = MagicMock()
+    model_class.from_pretrained.return_value = model
+    tokenizer_class = MagicMock()
+
+    provider = HuggingFaceProvider(model_class=model_class, tokenizer_class=tokenizer_class, device="cuda")
+    provider.load_model("dummy-model-id")
+
+    model.to.assert_called_once_with("cuda")
+    assert provider.model is moved_model
+
+
+def test_load_model_skips_to_when_no_device() -> None:
+    """When no device is configured, ``load_model`` does not call ``.to`` on the model."""
+    model = MagicMock()
+    model_class = MagicMock()
+    model_class.from_pretrained.return_value = model
+    tokenizer_class = MagicMock()
+
+    provider = HuggingFaceProvider(model_class=model_class, tokenizer_class=tokenizer_class)
+    provider.load_model("dummy-model-id")
+
+    model.to.assert_not_called()
+
+
+def test_pre_process_moves_tokens_to_device() -> None:
+    """Tokenized inputs are moved to the configured device before being returned."""
+    tokenized = MagicMock()
+    moved_tokens = MagicMock()
+    tokenized.to.return_value = moved_tokens
+    tokenizer = MagicMock(return_value=tokenized)
+
+    provider = HuggingFaceProvider(device="cpu")
+    provider.tokenizer = tokenizer
+
+    result = provider.pre_process("hello")
+
+    tokenized.to.assert_called_once_with("cpu")
+    assert result.data is moved_tokens
+
+
+def test_pre_process_skips_move_when_no_device() -> None:
+    """Tokenized inputs are returned untouched when no device is configured."""
+    tokenized = MagicMock()
+    tokenizer = MagicMock(return_value=tokenized)
+
+    provider = HuggingFaceProvider()
+    provider.tokenizer = tokenizer
+
+    result = provider.pre_process("hello")
+
+    tokenized.to.assert_not_called()
+    assert result.data is tokenized
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda", "mps", "cuda:0"])
+def test_device_passed_through(device: str) -> None:
+    """The provider stores arbitrary device strings without validation."""
+    provider = HuggingFaceProvider(device=device)
+    assert provider.device == device
+
+
+def test_load_model_uses_to_device_with_real_signature() -> None:
+    """End-to-end verification using ``patch`` on the real transformers loader interfaces."""
+    model = MagicMock()
+    moved_model = MagicMock()
+    model.to.return_value = moved_model
+    with (
+        patch(
+            "any_guardrail.providers.huggingface.AutoModelForSequenceClassification.from_pretrained",
+            return_value=model,
+        ),
+        patch("any_guardrail.providers.huggingface.AutoTokenizer.from_pretrained", return_value=MagicMock()),
+    ):
+        provider = HuggingFaceProvider(device="cuda")
+        provider.load_model("dummy")
+
+    assert provider.model is moved_model


### PR DESCRIPTION
## Summary

Closes #25.

- Adds a `device` parameter to `HuggingFaceProvider` so callers can load HuggingFace models onto a specific torch device (e.g. `cuda`, `mps`, `cuda:0`).
- `load_model` moves the model to the configured device, and `pre_process` moves tokenized inputs to the same device before inference.
- Updates guardrails that tokenize directly via `provider.tokenizer` (LlamaGuard, GraniteGuardian, ShieldGemma, HarmGuard) to also move tokens to the provider's device when set.
- Updates `.numpy()` calls in post-processing (`utils.match_injection_label`, HarmGuard) to `.cpu().numpy()` so post-processing works for non-CPU tensors.

## Test plan

- [x] New unit tests covering device-set and device-unset paths in `HuggingFaceProvider.__init__`, `load_model`, and `pre_process`.
- [x] Existing unit suite passes (`pytest -v tests/unit`).
- [x] `pre-commit run --all-files` passes (ruff, format, mypy, codespell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)