### PR TITLE
feat: support batch inference via list input to validate()

### DIFF
--- a/src/any_guardrail/base.py
+++ b/src/any_guardrail/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import StrEnum
-from typing import Any, ClassVar, Generic
+from typing import Any, ClassVar, Generic, overload
 
 from any_guardrail.types import (
     AnyDict,
@@ -127,7 +127,13 @@ class ThreeStageGuardrail(
         """
         ...
 
-    def validate(  # type: ignore[override]
+    @overload
+    def validate(self, input_text: str, **kwargs: Any) -> GuardrailOutput[ValidT, ExplanationT, ScoreT]: ...
+
+    @overload
+    def validate(self, input_text: list[str], **kwargs: Any) -> list[GuardrailOutput[ValidT, ExplanationT, ScoreT]]: ...
+
+    def validate(
         self, input_text: str | list[str], **kwargs: Any
     ) -> GuardrailOutput[ValidT, ExplanationT, ScoreT] | list[GuardrailOutput[ValidT, ExplanationT, ScoreT]]:
         """Default validation pipeline: preprocess -> inference -> postprocess.

--- a/src/any_guardrail/base.py
+++ b/src/any_guardrail/base.py
@@ -127,23 +127,58 @@ class ThreeStageGuardrail(
         """
         ...
 
-    def validate(self, input_text: str, **kwargs: Any) -> GuardrailOutput[ValidT, ExplanationT, ScoreT]:
+    def validate(  # type: ignore[override]
+        self, input_text: str | list[str], **kwargs: Any
+    ) -> GuardrailOutput[ValidT, ExplanationT, ScoreT] | list[GuardrailOutput[ValidT, ExplanationT, ScoreT]]:
         """Default validation pipeline: preprocess -> inference -> postprocess.
 
         Args:
-            input_text: The text to validate.
+            input_text: The text to validate. If a list is supplied, each item is
+                validated and a list of GuardrailOutputs is returned in the same
+                order. Subclasses can override ``_validate_batch`` to enable true
+                batched inference; the default iterates over inputs.
             **kwargs: Additional arguments passed to preprocessing (e.g., output_text, comparison_text).
 
         Returns:
-            GuardrailOutput with validation results.
+            GuardrailOutput when ``input_text`` is a string, or a list of
+            GuardrailOutputs when ``input_text`` is a list.
 
         Note:
             Subclasses can override this method to customize the signature or add validation logic.
 
         """
+        if isinstance(input_text, list):
+            return self._validate_batch(input_text, **kwargs)
         model_inputs = self._pre_processing(input_text, **kwargs)
         model_outputs = self._inference(model_inputs)
         return self._post_processing(model_outputs)
+
+    def _validate_batch(
+        self, input_texts: list[str], **kwargs: Any
+    ) -> list[GuardrailOutput[ValidT, ExplanationT, ScoreT]]:
+        """Validate a batch of inputs.
+
+        Default implementation iterates over the list and validates each item
+        independently. Subclasses that can perform true batched inference (e.g.
+        encoder classifiers via padded tokenization) should override this method
+        to take advantage of vectorized inference.
+
+        Args:
+            input_texts: The texts to validate.
+            **kwargs: Additional keyword arguments passed to each ``validate`` call.
+
+        Returns:
+            A list of GuardrailOutputs, one per input, in the same order.
+
+        """
+        results: list[GuardrailOutput[ValidT, ExplanationT, ScoreT]] = []
+        for text in input_texts:
+            result = self.validate(text, **kwargs)
+            if isinstance(result, list):
+                msg = "validate() returned a list for a single string input; check subclass overrides."
+                raise TypeError(msg)
+            results.append(result)
+        return results
 
 
 # Standard guardrail type alias

--- a/src/any_guardrail/guardrails/deepset/deepset.py
+++ b/src/any_guardrail/guardrails/deepset/deepset.py
@@ -1,7 +1,7 @@
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from any_guardrail.base import StandardGuardrail
-from any_guardrail.guardrails.utils import default, match_injection_label
+from any_guardrail.guardrails.utils import default, match_injection_label, match_injection_label_batch
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.types import BinaryScoreOutput, StandardInferenceOutput, StandardPreprocessOutput
@@ -33,3 +33,12 @@ class Deepset(StandardGuardrail):
 
     def _post_processing(self, model_outputs: StandardInferenceOutput) -> BinaryScoreOutput:
         return match_injection_label(model_outputs, DEEPSET_INJECTION_LABEL, self.provider.model.config.id2label)  # type: ignore[attr-defined]
+
+    def _validate_batch(self, input_texts: list[str], **kwargs: Any) -> list[BinaryScoreOutput]:
+        model_inputs = self.provider.pre_process(input_texts, **kwargs)
+        model_outputs = self.provider.infer(model_inputs)
+        return match_injection_label_batch(
+            model_outputs,
+            DEEPSET_INJECTION_LABEL,
+            self.provider.model.config.id2label,  # type: ignore[attr-defined]
+        )

--- a/src/any_guardrail/guardrails/granite_guardian/granite_guardian.py
+++ b/src/any_guardrail/guardrails/granite_guardian/granite_guardian.py
@@ -171,7 +171,7 @@ class GraniteGuardian(ThreeStageGuardrail[GraniteGuardianPreprocessData, Granite
             )
         self.provider.load_model(self.model_id)
 
-    def validate(
+    def validate(  # type: ignore[override]
         self,
         input_text: str,
         output_text: str | None = None,
@@ -205,13 +205,18 @@ class GraniteGuardian(ThreeStageGuardrail[GraniteGuardianPreprocessData, Granite
             block in think mode).
 
         """
-        return super().validate(
+        result = super().validate(
             input_text,
             output_text=output_text,
             documents=documents,
             available_tools=available_tools,
             **kwargs,
         )
+        # Granite Guardian only supports single-string inputs; ``super().validate``
+        # is statically typed as returning a union to support batch on other
+        # subclasses, but the runtime contract here is always a single output.
+        assert not isinstance(result, list)
+        return result
 
     def _build_guardian_block(self) -> str:
         judge_instruction = GUARDIAN_JUDGE_THINK if self.think else GUARDIAN_JUDGE_NOTHINK

--- a/src/any_guardrail/guardrails/granite_guardian/granite_guardian.py
+++ b/src/any_guardrail/guardrails/granite_guardian/granite_guardian.py
@@ -215,7 +215,9 @@ class GraniteGuardian(ThreeStageGuardrail[GraniteGuardianPreprocessData, Granite
         # Granite Guardian only supports single-string inputs; ``super().validate``
         # is statically typed as returning a union to support batch on other
         # subclasses, but the runtime contract here is always a single output.
-        assert not isinstance(result, list)
+        if isinstance(result, list):
+            msg = "GraniteGuardian.validate received a list input but only supports single strings."
+            raise TypeError(msg)
         return result
 
     def _build_guardian_block(self) -> str:

--- a/src/any_guardrail/guardrails/injec_guard/injec_guard.py
+++ b/src/any_guardrail/guardrails/injec_guard/injec_guard.py
@@ -1,7 +1,7 @@
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from any_guardrail.base import StandardGuardrail
-from any_guardrail.guardrails.utils import default, match_injection_label
+from any_guardrail.guardrails.utils import default, match_injection_label, match_injection_label_batch
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.types import BinaryScoreOutput, StandardInferenceOutput, StandardPreprocessOutput
@@ -33,3 +33,12 @@ class InjecGuard(StandardGuardrail):
 
     def _post_processing(self, model_outputs: StandardInferenceOutput) -> BinaryScoreOutput:
         return match_injection_label(model_outputs, INJECGUARD_LABEL, self.provider.model.config.id2label)  # type: ignore[attr-defined]
+
+    def _validate_batch(self, input_texts: list[str], **kwargs: Any) -> list[BinaryScoreOutput]:
+        model_inputs = self.provider.pre_process(input_texts, **kwargs)
+        model_outputs = self.provider.infer(model_inputs)
+        return match_injection_label_batch(
+            model_outputs,
+            INJECGUARD_LABEL,
+            self.provider.model.config.id2label,  # type: ignore[attr-defined]
+        )

--- a/src/any_guardrail/guardrails/jasper/jasper.py
+++ b/src/any_guardrail/guardrails/jasper/jasper.py
@@ -1,7 +1,7 @@
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from any_guardrail.base import StandardGuardrail
-from any_guardrail.guardrails.utils import default, match_injection_label
+from any_guardrail.guardrails.utils import default, match_injection_label, match_injection_label_batch
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.types import BinaryScoreOutput, StandardInferenceOutput, StandardPreprocessOutput
@@ -41,3 +41,12 @@ class Jasper(StandardGuardrail):
 
     def _post_processing(self, model_outputs: StandardInferenceOutput) -> BinaryScoreOutput:
         return match_injection_label(model_outputs, JASPER_INJECTION_LABEL, self.provider.model.config.id2label)  # type: ignore[attr-defined]
+
+    def _validate_batch(self, input_texts: list[str], **kwargs: Any) -> list[BinaryScoreOutput]:
+        model_inputs = self.provider.pre_process(input_texts, **kwargs)
+        model_outputs = self.provider.infer(model_inputs)
+        return match_injection_label_batch(
+            model_outputs,
+            JASPER_INJECTION_LABEL,
+            self.provider.model.config.id2label,  # type: ignore[attr-defined]
+        )

--- a/src/any_guardrail/guardrails/pangolin/pangolin.py
+++ b/src/any_guardrail/guardrails/pangolin/pangolin.py
@@ -1,7 +1,7 @@
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from any_guardrail.base import StandardGuardrail
-from any_guardrail.guardrails.utils import default, match_injection_label
+from any_guardrail.guardrails.utils import default, match_injection_label, match_injection_label_batch
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.types import BinaryScoreOutput, StandardInferenceOutput, StandardPreprocessOutput
@@ -33,3 +33,12 @@ class Pangolin(StandardGuardrail):
 
     def _post_processing(self, model_outputs: StandardInferenceOutput) -> BinaryScoreOutput:
         return match_injection_label(model_outputs, PANGOLIN_INJECTION_LABEL, self.provider.model.config.id2label)  # type: ignore[attr-defined]
+
+    def _validate_batch(self, input_texts: list[str], **kwargs: Any) -> list[BinaryScoreOutput]:
+        model_inputs = self.provider.pre_process(input_texts, **kwargs)
+        model_outputs = self.provider.infer(model_inputs)
+        return match_injection_label_batch(
+            model_outputs,
+            PANGOLIN_INJECTION_LABEL,
+            self.provider.model.config.id2label,  # type: ignore[attr-defined]
+        )

--- a/src/any_guardrail/guardrails/protectai/protectai.py
+++ b/src/any_guardrail/guardrails/protectai/protectai.py
@@ -1,7 +1,7 @@
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from any_guardrail.base import StandardGuardrail
-from any_guardrail.guardrails.utils import default, match_injection_label
+from any_guardrail.guardrails.utils import default, match_injection_label, match_injection_label_batch
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.types import BinaryScoreOutput, StandardInferenceOutput, StandardPreprocessOutput
@@ -38,3 +38,12 @@ class Protectai(StandardGuardrail):
 
     def _post_processing(self, model_outputs: StandardInferenceOutput) -> BinaryScoreOutput:
         return match_injection_label(model_outputs, PROTECTAI_INJECTION_LABEL, self.provider.model.config.id2label)  # type: ignore[attr-defined]
+
+    def _validate_batch(self, input_texts: list[str], **kwargs: Any) -> list[BinaryScoreOutput]:
+        model_inputs = self.provider.pre_process(input_texts, **kwargs)
+        model_outputs = self.provider.infer(model_inputs)
+        return match_injection_label_batch(
+            model_outputs,
+            PROTECTAI_INJECTION_LABEL,
+            self.provider.model.config.id2label,  # type: ignore[attr-defined]
+        )

--- a/src/any_guardrail/guardrails/sentinel/sentinel.py
+++ b/src/any_guardrail/guardrails/sentinel/sentinel.py
@@ -1,7 +1,7 @@
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from any_guardrail.base import StandardGuardrail
-from any_guardrail.guardrails.utils import default, match_injection_label
+from any_guardrail.guardrails.utils import default, match_injection_label, match_injection_label_batch
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.types import BinaryScoreOutput, StandardInferenceOutput, StandardPreprocessOutput
@@ -33,3 +33,12 @@ class Sentinel(StandardGuardrail):
 
     def _post_processing(self, model_outputs: StandardInferenceOutput) -> BinaryScoreOutput:
         return match_injection_label(model_outputs, SENTINEL_INJECTION_LABEL, self.provider.model.config.id2label)  # type: ignore[attr-defined]
+
+    def _validate_batch(self, input_texts: list[str], **kwargs: Any) -> list[BinaryScoreOutput]:
+        model_inputs = self.provider.pre_process(input_texts, **kwargs)
+        model_outputs = self.provider.infer(model_inputs)
+        return match_injection_label_batch(
+            model_outputs,
+            SENTINEL_INJECTION_LABEL,
+            self.provider.model.config.id2label,  # type: ignore[attr-defined]
+        )

--- a/src/any_guardrail/guardrails/utils.py
+++ b/src/any_guardrail/guardrails/utils.py
@@ -48,3 +48,27 @@ def match_injection_label(
     scores = _softmax(logits)  # type: ignore[no-untyped-call]
     label = id2label[scores.argmax().item()]
     return GuardrailOutput(valid=label != injection_label, score=scores.max().item())
+
+
+def match_injection_label_batch(
+    model_outputs: GuardrailInferenceOutput[AnyDict], injection_label: str, id2label: dict[int, str]
+) -> list[GuardrailOutput[bool, None, float]]:
+    """Match injection label for a batch of model outputs.
+
+    Args:
+        model_outputs: The wrapped inference output containing logits with a leading
+            batch dimension (shape ``(batch_size, num_classes)``).
+        injection_label: The label indicating injection/unsafe content.
+        id2label: Mapping from label IDs to label names.
+
+    Returns:
+        A list of GuardrailOutputs, one per input in the batch, in the same order.
+
+    """
+    logits = model_outputs.data["logits"].numpy()
+    scores = _softmax(logits)  # type: ignore[no-untyped-call]
+    outputs: list[GuardrailOutput[bool, None, float]] = []
+    for row in scores:
+        label = id2label[row.argmax().item()]
+        outputs.append(GuardrailOutput(valid=label != injection_label, score=row.max().item()))
+    return outputs

--- a/src/any_guardrail/guardrails/utils.py
+++ b/src/any_guardrail/guardrails/utils.py
@@ -65,7 +65,7 @@ def match_injection_label_batch(
         A list of GuardrailOutputs, one per input in the batch, in the same order.
 
     """
-    logits = model_outputs.data["logits"].numpy()
+    logits = model_outputs.data["logits"].detach().cpu().numpy()
     scores = _softmax(logits)  # type: ignore[no-untyped-call]
     outputs: list[GuardrailOutput[bool, None, float]] = []
     for row in scores:

--- a/src/any_guardrail/providers/huggingface.py
+++ b/src/any_guardrail/providers/huggingface.py
@@ -67,17 +67,22 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
         tokenizer_id = self.tokenizer_id or model_id
         self.tokenizer = self.tokenizer_class.from_pretrained(tokenizer_id, **load_kwargs)  # type: ignore[attr-defined]
 
-    def pre_process(self, input_text: str, **kwargs: Any) -> GuardrailPreprocessOutput[AnyDict]:
+    def pre_process(self, input_text: str | list[str], **kwargs: Any) -> GuardrailPreprocessOutput[AnyDict]:
         """Tokenize input text for model consumption.
 
         Args:
-            input_text: The text to preprocess.
+            input_text: A single text or a list of texts to preprocess. When a list
+                is supplied, ``padding=True`` is added automatically (unless caller
+                already specified a ``padding`` argument) so the resulting tensors
+                can be stacked into a batch.
             **kwargs: Additional keyword arguments passed to the tokenizer.
 
         Returns:
             GuardrailPreprocessOutput wrapping the tokenized input.
 
         """
+        if isinstance(input_text, list) and "padding" not in kwargs:
+            kwargs["padding"] = True
         tokenized = self.tokenizer(input_text, return_tensors="pt", **kwargs)
         return GuardrailPreprocessOutput(data=tokenized)
 

--- a/tests/unit/test_unit_batch_inference.py
+++ b/tests/unit/test_unit_batch_inference.py
@@ -1,0 +1,184 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+from any_guardrail import GuardrailOutput
+from any_guardrail.guardrails.deepset.deepset import DEEPSET_INJECTION_LABEL, Deepset
+from any_guardrail.guardrails.protectai.protectai import PROTECTAI_INJECTION_LABEL, Protectai
+from any_guardrail.guardrails.utils import match_injection_label, match_injection_label_batch
+from any_guardrail.providers.huggingface import HuggingFaceProvider
+from any_guardrail.types import GuardrailInferenceOutput
+
+
+@pytest.fixture
+def protectai_instance() -> Protectai:
+    """Build a Protectai instance with a mocked provider."""
+    instance = object.__new__(Protectai)
+    provider = MagicMock()
+    provider.model.config.id2label = {0: "SAFE", 1: PROTECTAI_INJECTION_LABEL}
+    instance.provider = provider
+    return instance
+
+
+@pytest.fixture
+def deepset_instance() -> Deepset:
+    """Build a Deepset instance with a mocked provider."""
+    instance = object.__new__(Deepset)
+    provider = MagicMock()
+    provider.model.config.id2label = {0: "SAFE", 1: DEEPSET_INJECTION_LABEL}
+    instance.provider = provider
+    return instance
+
+
+def test_pre_process_list_adds_padding() -> None:
+    """When given a list of texts, pre_process passes padding=True to the tokenizer."""
+    tokenizer = MagicMock(return_value={"input_ids": torch.tensor([[1, 2], [3, 4]])})
+
+    provider = HuggingFaceProvider()
+    provider.tokenizer = tokenizer
+
+    provider.pre_process(["hello", "world"])
+
+    _, kwargs = tokenizer.call_args
+    assert kwargs["padding"] is True
+    assert kwargs["return_tensors"] == "pt"
+
+
+def test_pre_process_list_respects_existing_padding_kwarg() -> None:
+    """When caller specifies padding, pre_process does not override it for lists."""
+    tokenizer = MagicMock(return_value={"input_ids": torch.tensor([[1, 2], [3, 4]])})
+
+    provider = HuggingFaceProvider()
+    provider.tokenizer = tokenizer
+
+    provider.pre_process(["hello", "world"], padding="max_length")
+
+    _, kwargs = tokenizer.call_args
+    assert kwargs["padding"] == "max_length"
+
+
+def test_pre_process_str_does_not_add_padding() -> None:
+    """A single string input is not auto-padded."""
+    tokenizer = MagicMock(return_value={"input_ids": torch.tensor([[1, 2, 3]])})
+
+    provider = HuggingFaceProvider()
+    provider.tokenizer = tokenizer
+
+    provider.pre_process("hello")
+
+    _, kwargs = tokenizer.call_args
+    assert "padding" not in kwargs
+
+
+def test_match_injection_label_batch_returns_list() -> None:
+    """The batch helper returns one GuardrailOutput per row of logits."""
+    # 2 inputs, 2 classes. Row 0 -> class 0 (SAFE), Row 1 -> class 1 (INJECTION).
+    logits = torch.tensor([[5.0, 0.0], [0.0, 5.0]])
+    outputs = match_injection_label_batch(
+        GuardrailInferenceOutput(data={"logits": logits}),
+        injection_label="INJECTION",
+        id2label={0: "SAFE", 1: "INJECTION"},
+    )
+
+    assert len(outputs) == 2
+    assert outputs[0].valid is True
+    assert outputs[1].valid is False
+    assert outputs[0].score is not None
+    assert outputs[1].score is not None
+    assert outputs[0].score > 0.99
+    assert outputs[1].score > 0.99
+
+
+def test_match_injection_label_single_unchanged() -> None:
+    """The single-input helper still returns a single GuardrailOutput from a 1-row batch."""
+    logits = torch.tensor([[5.0, 0.0]])
+    result = match_injection_label(
+        GuardrailInferenceOutput(data={"logits": logits}),
+        injection_label="INJECTION",
+        id2label={0: "SAFE", 1: "INJECTION"},
+    )
+
+    assert isinstance(result, GuardrailOutput)
+    assert result.valid is True
+
+
+def test_validate_batch_protectai_uses_batch_path(protectai_instance: Protectai) -> None:
+    """Calling validate with a list dispatches to _validate_batch on a standard guardrail."""
+    logits = torch.tensor([[5.0, 0.0], [0.0, 5.0]])
+    inference_output = GuardrailInferenceOutput(data={"logits": logits})
+
+    pre_output = MagicMock()
+    protectai_instance.provider.pre_process.return_value = pre_output  # type: ignore[attr-defined]
+    protectai_instance.provider.infer.return_value = inference_output  # type: ignore[attr-defined]
+
+    results = protectai_instance.validate(["safe text", "injection text"])
+
+    assert isinstance(results, list)
+    assert len(results) == 2
+    assert results[0].valid is True
+    assert results[1].valid is False
+    # pre_process gets the list directly (so the tokenizer can batch with padding).
+    protectai_instance.provider.pre_process.assert_called_once_with(["safe text", "injection text"])  # type: ignore[attr-defined]
+    # infer is called once for the entire batch.
+    protectai_instance.provider.infer.assert_called_once_with(pre_output)  # type: ignore[attr-defined]
+
+
+def test_validate_single_string_returns_single_output(protectai_instance: Protectai) -> None:
+    """Single-string validate keeps its existing single-output behavior."""
+    logits = torch.tensor([[5.0, 0.0]])
+    inference_output = GuardrailInferenceOutput(data={"logits": logits})
+
+    pre_output = MagicMock()
+    protectai_instance.provider.pre_process.return_value = pre_output  # type: ignore[attr-defined]
+    protectai_instance.provider.infer.return_value = inference_output  # type: ignore[attr-defined]
+
+    result = protectai_instance.validate("hello")
+
+    assert isinstance(result, GuardrailOutput)
+    assert result.valid is True
+
+
+def test_validate_batch_default_iterates() -> None:
+    """A guardrail that doesn't override _validate_batch falls back to per-item iteration."""
+    from any_guardrail.base import ThreeStageGuardrail
+    from any_guardrail.types import GuardrailPreprocessOutput
+
+    class FakeGuardrail(ThreeStageGuardrail[dict, dict, bool, None, float]):  # type: ignore[type-arg]
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def _pre_processing(self, input_text, **kwargs):  # type: ignore[no-untyped-def]
+            self.calls.append(input_text)
+            return GuardrailPreprocessOutput(data={"text": input_text})
+
+        def _inference(self, model_inputs):  # type: ignore[no-untyped-def]
+            return GuardrailInferenceOutput(data=model_inputs.data)
+
+        def _post_processing(self, model_outputs):  # type: ignore[no-untyped-def]
+            return GuardrailOutput(valid=True, score=1.0)
+
+    guardrail = FakeGuardrail()
+    results = guardrail.validate(["a", "b", "c"])
+
+    assert isinstance(results, list)
+    assert len(results) == 3
+    # The default _validate_batch goes through validate() per item, hitting _pre_processing each time.
+    assert guardrail.calls == ["a", "b", "c"]
+
+
+def test_match_injection_label_batch_uses_softmax_per_row() -> None:
+    """Softmax is applied independently per row so scores are well-formed probabilities."""
+    # Each row's max softmax score should be close to 1 / (1 + exp(-diff)).
+    logits = torch.tensor([[2.0, 1.0], [1.0, 3.0]])
+    outputs = match_injection_label_batch(
+        GuardrailInferenceOutput(data={"logits": logits}),
+        injection_label="INJECTION",
+        id2label={0: "SAFE", 1: "INJECTION"},
+    )
+
+    expected_row0 = float(np.exp(2.0) / (np.exp(2.0) + np.exp(1.0)))
+    expected_row1 = float(np.exp(3.0) / (np.exp(1.0) + np.exp(3.0)))
+    assert outputs[0].score == pytest.approx(expected_row0)
+    assert outputs[1].score == pytest.approx(expected_row1)


### PR DESCRIPTION
## Summary

Closes #21.

- `validate()` on `ThreeStageGuardrail` now accepts `str | list[str]`. A list input returns a list of `GuardrailOutput`s in the same order; a single string preserves the existing single-output behavior.
- New `_validate_batch` hook on `ThreeStageGuardrail` defaults to per-item iteration. Subclasses can override it for true batched inference.
- `HuggingFaceProvider.pre_process` now accepts a list of strings and auto-applies `padding=True` so the tokenizer can stack inputs into a batch tensor.
- New `match_injection_label_batch` utility returns one `GuardrailOutput` per row of batched logits.
- The 6 standard injection-detection guardrails (Protectai, Deepset, Sentinel, Jasper, Pangolin, InjecGuard) override `_validate_batch` to run a single batched forward pass via `match_injection_label_batch`.

## Test plan

- [x] New unit tests in `tests/unit/test_unit_batch_inference.py`:
  - `pre_process` adds `padding=True` for list inputs and skips it for strings.
  - `match_injection_label_batch` returns one output per row and uses per-row softmax.
  - `Protectai.validate(list)` dispatches to the batched path (single `pre_process` + single `infer` call).
  - `Protectai.validate(str)` still returns a single output.
  - A subclass that doesn't override `_validate_batch` falls back to per-item iteration.
- [x] Existing unit suite passes (`pytest -v tests/unit`).
- [x] `pre-commit run --files ...` passes (ruff, format, mypy, codespell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)