### PR TITLE
feat: surface explicit parameters on HuggingFaceProvider

### DIFF
--- a/src/any_guardrail/providers/huggingface.py
+++ b/src/any_guardrail/providers/huggingface.py
@@ -28,7 +28,20 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
             AutoModelForSequenceClassification.
         tokenizer_class: The transformers tokenizer class to use. Defaults to AutoTokenizer.
         tokenizer_id: Override the tokenizer model ID (defaults to the same as model_id).
-        trust_remote_code: Whether to trust remote code when loading models.
+        trust_remote_code: Whether to trust remote code when loading models. Forwarded
+            to both the model and tokenizer ``from_pretrained`` calls.
+        torch_dtype: The torch dtype to load the model with (e.g. ``torch.float16``,
+            ``torch.bfloat16``). Forwarded to the model's ``from_pretrained``.
+        cache_dir: Filesystem path used to cache downloaded model and tokenizer
+            files. Forwarded to ``from_pretrained`` for both model and tokenizer.
+        revision: The git revision (branch, tag, or commit) to load. Forwarded to
+            ``from_pretrained`` for both model and tokenizer.
+        model_kwargs: Additional keyword arguments to forward to the model's
+            ``from_pretrained``. Use this to set parameters not surfaced above
+            (e.g. ``device_map``, ``low_cpu_mem_usage``, ``attn_implementation``).
+        tokenizer_kwargs: Additional keyword arguments forwarded to the tokenizer
+            on every ``pre_process`` call (e.g. ``max_length``, ``truncation``,
+            ``padding``). Values can be overridden per-call.
 
     """
 
@@ -38,6 +51,11 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
         tokenizer_class: type | None = None,
         tokenizer_id: str | None = None,
         trust_remote_code: bool = False,
+        torch_dtype: Any | None = None,
+        cache_dir: str | None = None,
+        revision: str | None = None,
+        model_kwargs: AnyDict | None = None,
+        tokenizer_kwargs: AnyDict | None = None,
     ) -> None:
         """Initialize the HuggingFace provider."""
         if MISSING_PACKAGES_ERROR is not None:
@@ -48,27 +66,54 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
         self.tokenizer_class = tokenizer_class or AutoTokenizer
         self.tokenizer_id = tokenizer_id
         self.trust_remote_code = trust_remote_code
+        self.torch_dtype = torch_dtype
+        self.cache_dir = cache_dir
+        self.revision = revision
+        self.model_kwargs: AnyDict = dict(model_kwargs) if model_kwargs else {}
+        self.tokenizer_kwargs: AnyDict = dict(tokenizer_kwargs) if tokenizer_kwargs else {}
         self.model: Any = None
         self.tokenizer: Any = None
+
+    def _build_from_pretrained_kwargs(self) -> AnyDict:
+        """Collect the explicit, surfaced parameters into a kwargs dict for ``from_pretrained``."""
+        kwargs: AnyDict = {}
+        if self.trust_remote_code:
+            kwargs["trust_remote_code"] = True
+        if self.cache_dir is not None:
+            kwargs["cache_dir"] = self.cache_dir
+        if self.revision is not None:
+            kwargs["revision"] = self.revision
+        return kwargs
 
     def load_model(self, model_id: str, **kwargs: Any) -> None:
         """Load model and tokenizer from HuggingFace.
 
+        Surfaced provider-level parameters (``trust_remote_code``, ``torch_dtype``,
+        ``cache_dir``, ``revision``, ``model_kwargs``) are merged with the kwargs
+        passed here; call-site ``kwargs`` win on conflict.
+
         Args:
             model_id: The HuggingFace model identifier.
-            **kwargs: Additional keyword arguments passed to from_pretrained.
+            **kwargs: Additional keyword arguments passed to the model's
+                ``from_pretrained`` (override provider-level defaults).
 
         """
-        load_kwargs: AnyDict = {}
-        if self.trust_remote_code:
-            load_kwargs["trust_remote_code"] = True
+        common_kwargs = self._build_from_pretrained_kwargs()
 
-        self.model = self.model_class.from_pretrained(model_id, **load_kwargs, **kwargs)  # type: ignore[attr-defined]
+        model_load_kwargs: AnyDict = {**common_kwargs, **self.model_kwargs}
+        if self.torch_dtype is not None:
+            model_load_kwargs["torch_dtype"] = self.torch_dtype
+        model_load_kwargs.update(kwargs)
+
+        self.model = self.model_class.from_pretrained(model_id, **model_load_kwargs)  # type: ignore[attr-defined]
         tokenizer_id = self.tokenizer_id or model_id
-        self.tokenizer = self.tokenizer_class.from_pretrained(tokenizer_id, **load_kwargs)  # type: ignore[attr-defined]
+        self.tokenizer = self.tokenizer_class.from_pretrained(tokenizer_id, **common_kwargs)  # type: ignore[attr-defined]
 
     def pre_process(self, input_text: str, **kwargs: Any) -> GuardrailPreprocessOutput[AnyDict]:
         """Tokenize input text for model consumption.
+
+        Provider-level ``tokenizer_kwargs`` (e.g. ``max_length``, ``truncation``,
+        ``padding``) are applied first; per-call ``kwargs`` override them.
 
         Args:
             input_text: The text to preprocess.
@@ -78,7 +123,8 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
             GuardrailPreprocessOutput wrapping the tokenized input.
 
         """
-        tokenized = self.tokenizer(input_text, return_tensors="pt", **kwargs)
+        call_kwargs: AnyDict = {**self.tokenizer_kwargs, **kwargs}
+        tokenized = self.tokenizer(input_text, return_tensors="pt", **call_kwargs)
         return GuardrailPreprocessOutput(data=tokenized)
 
     def infer(self, model_inputs: GuardrailPreprocessOutput[AnyDict]) -> GuardrailInferenceOutput[AnyDict]:

--- a/src/any_guardrail/providers/huggingface.py
+++ b/src/any_guardrail/providers/huggingface.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, ClassVar
 
 try:
     import torch
@@ -49,6 +49,12 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
 
     """
 
+    # Keys that have dedicated constructor parameters and would create
+    # model/tokenizer mismatches if also passed via ``model_kwargs``.
+    _RESERVED_MODEL_KWARGS: ClassVar[frozenset[str]] = frozenset(
+        {"trust_remote_code", "cache_dir", "revision", "torch_dtype"}
+    )
+
     def __init__(
         self,
         model_class: type | None = None,
@@ -66,6 +72,16 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
         if MISSING_PACKAGES_ERROR is not None:
             msg = "Missing packages for HuggingFace provider. You can try `pip install 'any-guardrail[huggingface]'`"
             raise ImportError(msg) from MISSING_PACKAGES_ERROR
+
+        if model_kwargs:
+            reserved_used = self._RESERVED_MODEL_KWARGS & model_kwargs.keys()
+            if reserved_used:
+                msg = (
+                    f"model_kwargs cannot contain reserved keys {sorted(reserved_used)}; "
+                    f"use the dedicated constructor parameters instead so the model and "
+                    f"tokenizer stay in sync."
+                )
+                raise ValueError(msg)
 
         self.model_class = model_class or AutoModelForSequenceClassification
         self.tokenizer_class = tokenizer_class or AutoTokenizer
@@ -120,6 +136,8 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
 
         Provider-level ``tokenizer_kwargs`` (e.g. ``max_length``, ``truncation``,
         ``padding``) are applied first; per-call ``kwargs`` override them.
+        ``return_tensors`` defaults to ``"pt"`` but can be overridden via either
+        ``tokenizer_kwargs`` or per-call ``kwargs``.
 
         Args:
             input_text: The text to preprocess.
@@ -130,7 +148,8 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
 
         """
         call_kwargs: AnyDict = {**self.tokenizer_kwargs, **kwargs}
-        tokenized = self.tokenizer(input_text, return_tensors="pt", **call_kwargs)
+        call_kwargs.setdefault("return_tensors", "pt")
+        tokenized = self.tokenizer(input_text, **call_kwargs)
         if self.device is not None:
             tokenized = tokenized.to(self.device)
         return GuardrailPreprocessOutput(data=tokenized)

--- a/tests/unit/test_unit_huggingface_provider.py
+++ b/tests/unit/test_unit_huggingface_provider.py
@@ -1,0 +1,144 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from any_guardrail.providers.huggingface import HuggingFaceProvider
+
+
+@pytest.fixture
+def mock_classes() -> tuple[MagicMock, MagicMock]:
+    """Return mocked model and tokenizer classes whose ``from_pretrained`` returns a MagicMock."""
+    model_class = MagicMock()
+    model_class.from_pretrained.return_value = MagicMock()
+    tokenizer_class = MagicMock()
+    tokenizer_class.from_pretrained.return_value = MagicMock()
+    return model_class, tokenizer_class
+
+
+def test_defaults_have_no_extra_kwargs(mock_classes: tuple[MagicMock, MagicMock]) -> None:
+    """With no surfaced params set, ``from_pretrained`` is called without extras."""
+    model_class, tokenizer_class = mock_classes
+    provider = HuggingFaceProvider(model_class=model_class, tokenizer_class=tokenizer_class)
+    provider.load_model("dummy-id")
+
+    _, model_kwargs = model_class.from_pretrained.call_args
+    _, tokenizer_kwargs = tokenizer_class.from_pretrained.call_args
+    assert model_kwargs == {}
+    assert tokenizer_kwargs == {}
+
+
+def test_trust_remote_code_is_forwarded(mock_classes: tuple[MagicMock, MagicMock]) -> None:
+    """``trust_remote_code`` is passed to both model and tokenizer."""
+    model_class, tokenizer_class = mock_classes
+    provider = HuggingFaceProvider(model_class=model_class, tokenizer_class=tokenizer_class, trust_remote_code=True)
+    provider.load_model("dummy-id")
+
+    _, model_kwargs = model_class.from_pretrained.call_args
+    _, tokenizer_kwargs = tokenizer_class.from_pretrained.call_args
+    assert model_kwargs["trust_remote_code"] is True
+    assert tokenizer_kwargs["trust_remote_code"] is True
+
+
+def test_torch_dtype_passed_only_to_model(mock_classes: tuple[MagicMock, MagicMock]) -> None:
+    """``torch_dtype`` belongs on the model loader, not the tokenizer."""
+    model_class, tokenizer_class = mock_classes
+    sentinel_dtype = object()
+    provider = HuggingFaceProvider(model_class=model_class, tokenizer_class=tokenizer_class, torch_dtype=sentinel_dtype)
+    provider.load_model("dummy-id")
+
+    _, model_kwargs = model_class.from_pretrained.call_args
+    _, tokenizer_kwargs = tokenizer_class.from_pretrained.call_args
+    assert model_kwargs["torch_dtype"] is sentinel_dtype
+    assert "torch_dtype" not in tokenizer_kwargs
+
+
+def test_cache_dir_and_revision_passed_to_both(mock_classes: tuple[MagicMock, MagicMock]) -> None:
+    """``cache_dir`` and ``revision`` are forwarded to both model and tokenizer."""
+    model_class, tokenizer_class = mock_classes
+    provider = HuggingFaceProvider(
+        model_class=model_class,
+        tokenizer_class=tokenizer_class,
+        cache_dir="/some/cache",
+        revision="main",
+    )
+    provider.load_model("dummy-id")
+
+    _, model_kwargs = model_class.from_pretrained.call_args
+    _, tokenizer_kwargs = tokenizer_class.from_pretrained.call_args
+    assert model_kwargs["cache_dir"] == "/some/cache"
+    assert tokenizer_kwargs["cache_dir"] == "/some/cache"
+    assert model_kwargs["revision"] == "main"
+    assert tokenizer_kwargs["revision"] == "main"
+
+
+def test_model_kwargs_forwarded_to_model_only(mock_classes: tuple[MagicMock, MagicMock]) -> None:
+    """``model_kwargs`` is a model-only forwarding bag for less common params."""
+    model_class, tokenizer_class = mock_classes
+    provider = HuggingFaceProvider(
+        model_class=model_class,
+        tokenizer_class=tokenizer_class,
+        model_kwargs={"device_map": "auto", "low_cpu_mem_usage": True},
+    )
+    provider.load_model("dummy-id")
+
+    _, model_kwargs = model_class.from_pretrained.call_args
+    _, tokenizer_kwargs = tokenizer_class.from_pretrained.call_args
+    assert model_kwargs["device_map"] == "auto"
+    assert model_kwargs["low_cpu_mem_usage"] is True
+    assert "device_map" not in tokenizer_kwargs
+
+
+def test_load_model_kwargs_override_provider_defaults(mock_classes: tuple[MagicMock, MagicMock]) -> None:
+    """Kwargs passed to ``load_model`` win over surfaced provider defaults on conflict."""
+    model_class, tokenizer_class = mock_classes
+    provider = HuggingFaceProvider(
+        model_class=model_class,
+        tokenizer_class=tokenizer_class,
+        model_kwargs={"device_map": "auto"},
+    )
+    provider.load_model("dummy-id", device_map="cuda:0")
+
+    _, model_kwargs = model_class.from_pretrained.call_args
+    assert model_kwargs["device_map"] == "cuda:0"
+
+
+def test_tokenizer_kwargs_applied_per_call() -> None:
+    """``tokenizer_kwargs`` are applied to every ``pre_process`` invocation."""
+    tokenizer = MagicMock(return_value={"input_ids": [[1, 2, 3]]})
+    provider = HuggingFaceProvider(tokenizer_kwargs={"max_length": 128, "truncation": True})
+    provider.tokenizer = tokenizer
+
+    provider.pre_process("hello")
+
+    _, kwargs = tokenizer.call_args
+    assert kwargs["max_length"] == 128
+    assert kwargs["truncation"] is True
+    assert kwargs["return_tensors"] == "pt"
+
+
+def test_per_call_kwargs_override_provider_tokenizer_kwargs() -> None:
+    """Per-call kwargs on ``pre_process`` override the provider-level defaults."""
+    tokenizer = MagicMock(return_value={"input_ids": [[1, 2, 3]]})
+    provider = HuggingFaceProvider(tokenizer_kwargs={"max_length": 128})
+    provider.tokenizer = tokenizer
+
+    provider.pre_process("hello", max_length=512)
+
+    _, kwargs = tokenizer.call_args
+    assert kwargs["max_length"] == 512
+
+
+def test_model_kwargs_none_does_not_error() -> None:
+    """Passing ``None`` (the default) yields an empty internal dict, not a None reference."""
+    provider = HuggingFaceProvider()
+    assert provider.model_kwargs == {}
+    assert provider.tokenizer_kwargs == {}
+
+
+def test_provider_does_not_mutate_caller_dicts() -> None:
+    """The provider copies caller-supplied dicts so later caller mutations don't leak in."""
+    caller_dict = {"device_map": "auto"}
+    provider = HuggingFaceProvider(model_kwargs=caller_dict)
+    caller_dict["device_map"] = "cpu"
+
+    assert provider.model_kwargs["device_map"] == "auto"

--- a/tests/unit/test_unit_huggingface_provider.py
+++ b/tests/unit/test_unit_huggingface_provider.py
@@ -216,6 +216,37 @@ def test_device_passed_through(device: str) -> None:
     assert provider.device == device
 
 
+@pytest.mark.parametrize("reserved_key", ["trust_remote_code", "cache_dir", "revision", "torch_dtype"])
+def test_reserved_keys_in_model_kwargs_rejected(reserved_key: str) -> None:
+    """Reserved keys in ``model_kwargs`` raise ValueError to prevent model/tokenizer mismatches."""
+    with pytest.raises(ValueError, match="reserved keys"):
+        HuggingFaceProvider(model_kwargs={reserved_key: "anything"})
+
+
+def test_pre_process_return_tensors_can_be_overridden_via_tokenizer_kwargs() -> None:
+    """``return_tensors`` set in ``tokenizer_kwargs`` is honored instead of crashing on a duplicate kwarg."""
+    tokenizer = MagicMock(return_value={"input_ids": [[1, 2, 3]]})
+    provider = HuggingFaceProvider(tokenizer_kwargs={"return_tensors": "np"})
+    provider.tokenizer = tokenizer
+
+    provider.pre_process("hello")
+
+    _, kwargs = tokenizer.call_args
+    assert kwargs["return_tensors"] == "np"
+
+
+def test_pre_process_return_tensors_can_be_overridden_per_call() -> None:
+    """``return_tensors`` set as a per-call kwarg is honored instead of crashing on a duplicate kwarg."""
+    tokenizer = MagicMock(return_value={"input_ids": [[1, 2, 3]]})
+    provider = HuggingFaceProvider()
+    provider.tokenizer = tokenizer
+
+    provider.pre_process("hello", return_tensors="np")
+
+    _, kwargs = tokenizer.call_args
+    assert kwargs["return_tensors"] == "np"
+
+
 def test_load_model_uses_to_device_with_real_signature() -> None:
     """End-to-end verification using ``patch`` on the real transformers loader interfaces."""
     model = MagicMock()


### PR DESCRIPTION
## Summary

Closes #71.

Replaces the opaque `**kwargs` forwarding on `HuggingFaceProvider` with explicit, documented parameters, so users can configure the underlying `transformers` calls without having to read source code.

- `torch_dtype`, `cache_dir`, `revision`: common `from_pretrained` parameters, surfaced directly on the constructor.
- `model_kwargs`: typed dict for advanced model-only `from_pretrained` parameters that aren't worth a dedicated constructor argument (`device_map`, `low_cpu_mem_usage`, `attn_implementation`, etc.).
- `tokenizer_kwargs`: typed dict for default tokenizer call kwargs (`max_length`, `truncation`, `padding`) applied to every `pre_process` invocation. Per-call kwargs win on conflict.
- `cache_dir`/`revision` are forwarded to both model and tokenizer; `torch_dtype` and `model_kwargs` only to the model loader (so unexpected kwargs don't reach the tokenizer).
- `load_model(**kwargs)` still works and takes precedence over provider-level defaults.

## Test plan

- [x] New unit tests in `tests/unit/test_unit_huggingface_provider.py`:
  - Defaults don't pass any extras to `from_pretrained`.
  - `trust_remote_code` reaches both model and tokenizer.
  - `torch_dtype` only reaches the model.
  - `cache_dir` and `revision` reach both.
  - `model_kwargs` reaches the model only.
  - `load_model` kwargs override provider-level defaults on conflict.
  - `tokenizer_kwargs` are applied on every `pre_process` call; per-call kwargs override them.
  - Caller-supplied dicts aren't mutated by the provider.
- [x] Existing unit suite passes (`pytest -v tests/unit`).
- [x] `pre-commit run --files ...` passes (ruff, format, mypy, codespell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)