### PR TITLE
tests: replace RUNNING_IN_CI gating with @pytest.mark.e2e + @pytest.mark.heavy markers

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -7,6 +7,11 @@ on:
       - 'src/**'
       - 'tests/**'
   workflow_dispatch:
+    inputs:
+      include_heavy:
+        description: "Also run heavy e2e tests (ShieldGemma, Glider, Granite Guardian — need >5 GB RAM / a GPU)"
+        type: boolean
+        default: false
 
 jobs:
   run-integration-tests:
@@ -35,4 +40,12 @@ jobs:
           ALINIA_API_KEY: ${{ secrets.ALINIA_API_KEY }}
           HF_HUB_DOWNLOAD_TIMEOUT: "300"
           HF_HUB_ETAG_TIMEOUT: "30"
-        run: pytest -v tests/integration --reruns 3 --reruns-delay 10 --timeout 600
+        # `e2e` is auto-applied to every test under tests/integration/ by the
+        # directory conftest. `heavy` opt-in flips on the >5 GB models that
+        # don't fit on a vanilla GitHub runner.
+        run: |
+          if [ "${{ github.event.inputs.include_heavy }}" = "true" ]; then
+            pytest -v -m e2e tests/integration --reruns 3 --reruns-delay 10 --timeout 1800
+          else
+            pytest -v -m "e2e and not heavy" tests/integration --reruns 3 --reruns-delay 10 --timeout 600
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,11 @@ ignore_missing_imports = true # pytest related modules are not found
 
 [tool.pytest.ini_options]
 timeout = 120
+addopts = "--strict-markers"
+markers = [
+    "e2e: tests that exercise real binaries / downloaded models / external APIs. Selected explicitly via -m e2e; not run by default in CI's unit-test job. Run locally with `pytest -m e2e tests/integration`.",
+    "heavy: e2e subset that needs >5 GB RAM/disk or a GPU to be realistic (currently: Granite Guardian, ShieldGemma, Glider). Run with `-m \"e2e and heavy\"` only on machines that can host the model weights.",
+]
 
 [dependency-groups]
 dev = [

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,29 @@
+"""Auto-mark every test under ``tests/integration/`` as ``e2e``.
+
+By convention this directory holds tests that exercise real binaries, real
+models downloaded from HuggingFace, or real external APIs — i.e. e2e tests.
+Rather than annotate each module with ``pytestmark = pytest.mark.e2e``,
+we apply the marker once here so new integration tests pick it up
+automatically. Individual files only need to add ``pytest.mark.heavy``
+(or other narrower marks) when they apply.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def pytest_collection_modifyitems(items: Iterable[pytest.Item]) -> None:
+    """Add the ``e2e`` marker to every test collected from this directory."""
+    e2e = pytest.mark.e2e
+    for item in items:
+        # ``pytest_collection_modifyitems`` is called with the global item list
+        # even when the conftest lives in a subdirectory. Scope the marker
+        # application to items whose nodeid lives under this directory.
+        if "tests/integration/" in item.nodeid.replace("\\", "/"):
+            item.add_marker(e2e)

--- a/tests/integration/test_granite_guardian.py
+++ b/tests/integration/test_granite_guardian.py
@@ -2,24 +2,23 @@
 
 Reproduces worked examples from the
 [ibm-granite/granite-guardian-4.1-8b model card](https://huggingface.co/ibm-granite/granite-guardian-4.1-8b)
-and asserts the expected scores. Skipped in CI (the 8B model needs ~16 GB RAM
-and a GPU to be practical); run locally on a GPU box whenever the wrapper or
-its underlying transformers version changes.
+and asserts the expected scores. The 8B model needs ~16 GB RAM and a GPU to be
+practical; run with ``pytest -m "e2e and heavy"`` on a machine that can host
+the weights whenever the wrapper or its underlying transformers version
+changes.
 """
 
 import json
-import os
 
 import pytest
 
 from any_guardrail import AnyGuardrail, GuardrailName
 from any_guardrail.guardrails.granite_guardian import GraniteGuardianRisk
 
-RUNNING_IN_CI = os.environ.get("CI") == "true"
-
-pytestmark = pytest.mark.skipif(
-    RUNNING_IN_CI, reason="Model too large for CI runners (~16GB, needs 20GB+ RAM and a GPU)"
-)
+# `e2e` is applied automatically by tests/integration/conftest.py. The 8B
+# Granite Guardian model also needs ~16 GB RAM and a GPU to be practical,
+# so mark the whole module `heavy` too.
+pytestmark = pytest.mark.heavy
 
 
 def test_safety_harm() -> None:

--- a/tests/integration/test_huggingface_guardrails.py
+++ b/tests/integration/test_huggingface_guardrails.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any
 
 import pytest
@@ -7,7 +6,9 @@ from any_guardrail import AnyGuardrail, GuardrailName
 from any_guardrail.base import GuardrailOutput, ThreeStageGuardrail
 from any_guardrail.guardrails.duo_guard.duo_guard import DUOGUARD_CATEGORIES
 
-RUNNING_IN_CI = os.environ.get("CI") == "true"
+# All tests in tests/integration/ are auto-marked `e2e` by the directory
+# conftest. Individual tests in this module that need a beefy runner are
+# additionally marked `heavy` below.
 
 
 @pytest.mark.parametrize(
@@ -26,7 +27,7 @@ RUNNING_IN_CI = os.environ.get("CI") == "true"
             GuardrailName.SHIELD_GEMMA,
             {"policy": "Do not provide harmful or dangerous information"},
             None,
-            marks=pytest.mark.skipif(RUNNING_IN_CI, reason="Model too large for CI runners (~5GB, needs 8GB+ RAM)"),
+            marks=pytest.mark.heavy,  # ~5 GB, needs 8 GB+ RAM
         ),
         pytest.param(
             GuardrailName.GLIDER,
@@ -35,13 +36,13 @@ RUNNING_IN_CI = os.environ.get("CI") == "true"
                 "rubric": "0: If information is safe. 1: If information is dangerous",
             },
             None,
-            marks=pytest.mark.skipif(RUNNING_IN_CI, reason="Model too large for CI runners (~8GB, needs 10GB+ RAM)"),
+            marks=pytest.mark.heavy,  # ~8 GB, needs 10 GB+ RAM
         ),
         pytest.param(
             GuardrailName.GRANITE_GUARDIAN,
             {"criteria": "The text contains harmful or dangerous content."},
             None,
-            marks=pytest.mark.skipif(RUNNING_IN_CI, reason="Model too large for CI runners (~16GB, needs 20GB+ RAM)"),
+            marks=pytest.mark.heavy,  # ~16 GB, needs 20 GB+ RAM
         ),
     ],
 )


### PR DESCRIPTION
## Summary

Replaces the ad-hoc `RUNNING_IN_CI = os.environ.get("CI") == "true"` gating pattern in integration tests with proper pytest markers, per [@javiermtorres's review comment on PR #160](https://github.com/mozilla-ai/any-guardrail/pull/160#discussion_r3287241652) (\"the control of what to run should be left to some layer above\").

Two commits:

1. **`refactor(tests)`** — registers the `e2e` + `heavy` markers in `pyproject.toml`, adds a directory-scope `tests/integration/conftest.py` that auto-applies `@pytest.mark.e2e` to every test in there (so new integration tests pick it up for free), and replaces the per-file `RUNNING_IN_CI` skipif patterns with `@pytest.mark.heavy` on the >5 GB-model tests (ShieldGemma, Glider, Granite Guardian).
2. **`ci(integration)`** — updates `.github/workflows/tests-integration.yaml` to skip heavy tests by default (matching the previous `CI=true` behavior) and adds a `workflow_dispatch.inputs.include_heavy` checkbox for manually running them. Heavy timeout bumped to 1800s.

## Why this isn't bundled into PR #160

PR #160 only touches `tests/integration/test_encoderfile.py`. This refactor hits `test_huggingface_guardrails.py` + `test_granite_guardian.py` + `pyproject.toml` + the integration workflow, all on main. Keeping it as its own PR avoids dragging unrelated test files into the encoderfile review surface.

## What about `test_encoderfile.py`?

`test_encoderfile.py` lands on `encoderfile-provider` (PR #160) and still uses the old `RUNNING_IN_CI` pattern. It'll be migrated to the marker in a follow-up commit on that branch after this lands and PR #160 rebases on main. No conflict in the meantime — the old pattern keeps working.

## Selection matrix (verified locally)

| Selector | Count | Tests |
|---|---|---|
| `pytest -m e2e tests/integration` | 21 | everything |
| `pytest -m "e2e and not heavy" tests/integration` | 15 | deepset, duo_guard, harm_guard, injec_guard, jasper, pangolin, llama_guard, protectai, sentinel, off_topic, alinia, any_llm, 3x azure |
| `pytest -m "e2e and heavy" tests/integration` | 6 | shield_gemma, glider, granite_guardian, 3x granite_guardian |
| `pytest -m "not e2e" tests/integration` | 0 | (clean — everything in there is e2e) |

## Test plan

- [x] `pytest -m e2e --collect-only -q tests/integration` collects 21 tests.
- [x] `pytest -m "e2e and not heavy" --collect-only -q tests/integration` collects 15.
- [x] `pytest -m "e2e and heavy" --collect-only -q tests/integration` collects 6.
- [x] `pytest -m "not e2e" --collect-only -q tests/integration` collects 0.
- [x] `pre-commit run --all-files` green.
- [ ] After merge: the `Integration Tests` workflow runs on push to main with the default (`not heavy`) filter and produces the same coverage that the old `CI=true` gate did.
- [ ] After merge: trigger the workflow manually with `include_heavy=true` and confirm heavy tests at least start (they'll likely OOM the runner, which is the expected failure mode for those on shared hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)