### PR TITLE
feat(guardrails): add Cleanlab TLM hallucination/trustworthiness guardrail

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,6 +19,7 @@
   * [Alinia](api/guardrails/alinia.md)
   * [AnyLLM](api/guardrails/any-llm.md)
   * [Azure Content Safety](api/guardrails/azure-content-safety.md)
+  * [Cleanlab TLM](api/guardrails/cleanlab-tlm.md)
   * [Deepset](api/guardrails/deepset.md)
   * [DuoGuard](api/guardrails/duo-guard.md)
   * [FlowJudge](api/guardrails/flowjudge.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 
 [project.optional-dependencies]
 all = [
-  "any-guardrail[flowjudge,huggingface,azure-content-safety,encoderfile]"
+  "any-guardrail[flowjudge,huggingface,azure-content-safety,encoderfile,cleanlab-tlm]"
 ]
 
 flowjudge = [
@@ -38,6 +38,10 @@ encoderfile = [
     "huggingface-hub>=0.33.4",
     "hf-xet>=1.1.5",
     "numpy>=1.26",
+]
+
+cleanlab-tlm = [
+    "cleanlab-tlm>=1.0.0"
 ]
 
 [project.urls]

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -329,6 +329,7 @@ GUARDRAILS = [
         "AzureContentSafety",
         "azure-content-safety.md",
     ),
+    ("any_guardrail.guardrails.cleanlab_tlm.cleanlab_tlm", "CleanlabTlm", "cleanlab-tlm.md"),
     ("any_guardrail.guardrails.deepset.deepset", "Deepset", "deepset.md"),
     ("any_guardrail.guardrails.duo_guard.duo_guard", "DuoGuard", "duo-guard.md"),
     ("any_guardrail.guardrails.flowjudge.flowjudge", "Flowjudge", "flowjudge.md"),

--- a/src/any_guardrail/base.py
+++ b/src/any_guardrail/base.py
@@ -26,6 +26,7 @@ class GuardrailName(StrEnum):
     """String enum for supported guardrails."""
 
     ANYLLM = "any_llm"
+    CLEANLAB_TLM = "cleanlab_tlm"
     DEEPSET = "deepset"
     DUOGUARD = "duo_guard"
     FLOWJUDGE = "flowjudge"

--- a/src/any_guardrail/guardrails/cleanlab_tlm/__init__.py
+++ b/src/any_guardrail/guardrails/cleanlab_tlm/__init__.py
@@ -1,0 +1,3 @@
+from .cleanlab_tlm import CleanlabTlm
+
+__all__ = ["CleanlabTlm"]

--- a/src/any_guardrail/guardrails/cleanlab_tlm/cleanlab_tlm.py
+++ b/src/any_guardrail/guardrails/cleanlab_tlm/cleanlab_tlm.py
@@ -1,0 +1,151 @@
+import os
+from typing import Any, ClassVar, Literal, cast
+
+from any_guardrail.base import Guardrail, GuardrailOutput
+
+CleanlabQualityPreset = Literal["base", "low", "medium", "high", "best"]
+CleanlabTask = Literal["default", "classification", "code_generation"]
+
+
+class CleanlabTlm(Guardrail[bool, dict[str, Any], float]):
+    """Wraps Cleanlab's Trustworthy Language Model (TLM) for hallucination / trustworthiness scoring.
+
+    Cleanlab TLM is a hosted scoring service that returns a scalar trustworthiness score in ``[0, 1]``
+    for any ``(prompt, response)`` pair. It is designed to detect hallucinations and low-confidence
+    answers in RAG and agent pipelines.
+
+    This guardrail is a **hallucination / trustworthiness scoring** guardrail — it is NOT a content
+    moderation classifier. It does not detect harmful content, prompt injection, jailbreaks, or
+    policy violations. It estimates how confident the model is that a given ``response`` is correct
+    for a given ``prompt``.
+
+    Output semantics are **inverted** relative to most safety classifiers in ``any-guardrail``:
+    a higher score means MORE trustworthy and therefore MORE valid. ``valid`` is ``True`` when the
+    score is greater than or equal to ``threshold``.
+
+    Authentication: requires a Cleanlab TLM API key. Pass via the ``api_key=`` constructor argument
+    or set the ``CLEANLAB_TLM_API_KEY`` environment variable. Sign up at https://tlm.cleanlab.ai/
+    (Cleanlab offers $5 of free credits at signup; usage is pay-as-you-go thereafter).
+
+    Research backing:
+        - Chen & Mueller, *Quantifying Uncertainty in Answers from any Language Model and Enhancing
+          their Trustworthiness*, ACL 2024 — the BSDetector methodology underlying TLM.
+          https://aclanthology.org/2024.acl-long.283/
+        - Cleanlab agent-architecture hallucination benchmarks — TLM detects incorrect RAG responses
+          with ~3x the precision of RAGAS / groundedness baselines.
+          https://cleanlab.ai/blog/agent-tlm-hallucination-benchmarking/
+        - TLM documentation: https://help.cleanlab.ai/tlm/
+
+    Args:
+        model_id: One of ``CleanlabTlm.SUPPORTED_MODELS`` (``"TLM"`` or ``"TLM-Lite"``). Defaults to
+            ``"TLM"``. ``"TLM-Lite"`` is the cheaper variant.
+        api_key: Cleanlab TLM API key. If ``None``, falls back to ``CLEANLAB_TLM_API_KEY`` env var.
+        quality_preset: One of ``{"base", "low", "medium", "high", "best"}``. Higher quality presets
+            consume more credits per call. Defaults to ``"medium"``.
+        task: One of ``{"default", "classification", "code_generation"}``. Tunes TLM for a specific
+            downstream task type. Defaults to ``"default"``.
+
+    """
+
+    SUPPORTED_MODELS: ClassVar = ["TLM", "TLM-Lite"]
+
+    def __init__(
+        self,
+        model_id: str | None = None,
+        api_key: str | None = None,
+        quality_preset: CleanlabQualityPreset = "medium",
+        task: CleanlabTask = "default",
+    ) -> None:
+        """Initialize the Cleanlab TLM guardrail and instantiate its underlying client.
+
+        Args:
+            model_id: One of ``CleanlabTlm.SUPPORTED_MODELS``. Defaults to ``"TLM"``.
+            api_key: Cleanlab TLM API key. If ``None``, falls back to the ``CLEANLAB_TLM_API_KEY``
+                environment variable. Raises ``ValueError`` if no key is found.
+            quality_preset: Quality preset for scoring. One of
+                ``{"base", "low", "medium", "high", "best"}``.
+            task: Task type for scoring. One of ``{"default", "classification", "code_generation"}``.
+
+        Raises:
+            ValueError: If no API key is supplied and ``CLEANLAB_TLM_API_KEY`` is not set.
+            ImportError: If the ``cleanlab-tlm`` package is not installed. Install with
+                ``pip install 'any-guardrail[cleanlab-tlm]'``.
+
+        """
+        if model_id is None:
+            self.model_id = self.SUPPORTED_MODELS[0]
+        elif model_id not in self.SUPPORTED_MODELS:
+            msg = f"Only supports {self.SUPPORTED_MODELS}, got '{model_id}'."
+            raise ValueError(msg)
+        else:
+            self.model_id = model_id
+
+        resolved_key = api_key if api_key is not None else os.getenv("CLEANLAB_TLM_API_KEY")
+        if not resolved_key:
+            msg = (
+                "Cleanlab TLM API key must be provided either via the `api_key=` constructor "
+                "argument or the `CLEANLAB_TLM_API_KEY` environment variable. "
+                "Sign up at https://tlm.cleanlab.ai/ to obtain a key."
+            )
+            raise ValueError(msg)
+        self.api_key = resolved_key
+        self.quality_preset = quality_preset
+        self.task = task
+
+        try:
+            from cleanlab_tlm import TLM
+        except ImportError as exc:
+            msg = (
+                "The `cleanlab-tlm` package is required to use the CleanlabTlm guardrail. "
+                "Install it with `pip install 'any-guardrail[cleanlab-tlm]'`."
+            )
+            raise ImportError(msg) from exc
+
+        self.tlm = TLM(
+            api_key=self.api_key,
+            quality_preset=self.quality_preset,
+            task=self.task,
+        )
+
+    def validate(
+        self,
+        prompt: str,
+        response: str,
+        threshold: float = 0.7,
+    ) -> GuardrailOutput[bool, dict[str, Any], float]:
+        """Score the trustworthiness of ``response`` given ``prompt`` via Cleanlab TLM.
+
+        Note:
+            Output semantics are inverted relative to most ``any-guardrail`` guardrails: a HIGHER
+            trustworthiness score means MORE trustworthy (and therefore MORE valid). ``valid`` is
+            ``True`` when ``score >= threshold``.
+
+        Args:
+            prompt: The prompt presented to the LLM.
+            response: The response produced by the LLM that we want to score for trustworthiness.
+            threshold: Minimum trustworthiness score in ``[0, 1]`` for the response to be considered
+                valid. Defaults to ``0.7``.
+
+        Returns:
+            A ``GuardrailOutput`` with:
+
+            - ``valid``: ``True`` if ``trustworthiness_score >= threshold``, else ``False``.
+            - ``score``: The raw trustworthiness score from TLM.
+            - ``explanation``: The ``log`` dict returned by TLM (which may include a free-text
+              ``"explanation"`` field) merged with the trustworthiness score for convenience.
+
+        """
+        raw_result = self.tlm.get_trustworthiness_score(prompt=prompt, response=response)
+        # ``get_trustworthiness_score`` returns ``TLMScore | list[TLMScore]`` depending on whether
+        # the inputs were strings or sequences. We always pass single strings here, so the result is
+        # the dict-shaped TLMScore branch.
+        result = cast("dict[str, Any]", raw_result)
+        raw_score = result.get("trustworthiness_score")
+        if raw_score is None:
+            msg = f"Cleanlab TLM did not return a trustworthiness score. Full response: {result!r}"
+            raise RuntimeError(msg)
+        score = float(raw_score)
+        valid = score >= threshold
+        log_dict = cast("dict[str, Any]", result.get("log", {})) or {}
+        explanation: dict[str, Any] = {**log_dict, "trustworthiness_score": score}
+        return GuardrailOutput(valid=valid, explanation=explanation, score=score)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -9,6 +9,7 @@ from any_guardrail.base import Guardrail, ThreeStageGuardrail
 from any_guardrail.guardrails.alinia import Alinia
 from any_guardrail.guardrails.any_llm import AnyLlm
 from any_guardrail.guardrails.azure_content_safety import AzureContentSafety
+from any_guardrail.guardrails.cleanlab_tlm import CleanlabTlm
 from any_guardrail.guardrails.glider.glider import Glider
 from any_guardrail.guardrails.llama_guard import LlamaGuard
 from any_guardrail.guardrails.off_topic.off_topic import OffTopic
@@ -96,6 +97,7 @@ def test_model_load() -> None:
             or guardrail_class is LlamaGuard
             or guardrail_class is AzureContentSafety
             or guardrail_class is Alinia
+            or guardrail_class is CleanlabTlm  # API-key based, no provider
             or guardrail_class is Glider  # Loads model directly, no provider
             or guardrail_class is OffTopic  # Loads model directly, no provider
         ):

--- a/tests/unit/test_unit_cleanlab_tlm.py
+++ b/tests/unit/test_unit_cleanlab_tlm.py
@@ -1,0 +1,140 @@
+"""Unit tests for the CleanlabTlm guardrail.
+
+These tests mock the underlying ``cleanlab_tlm.TLM`` client so no real API calls are made.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from any_guardrail.base import GuardrailOutput
+
+
+def _install_fake_cleanlab_tlm(monkeypatch: pytest.MonkeyPatch) -> mock.MagicMock:
+    """Install a fake ``cleanlab_tlm`` module exposing a mocked ``TLM`` class.
+
+    Returns the ``TLM`` class mock so individual tests can configure its instances.
+    """
+    fake_module = ModuleType("cleanlab_tlm")
+    tlm_cls = mock.MagicMock(name="TLM")
+    fake_module.TLM = tlm_cls  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "cleanlab_tlm", fake_module)
+    return tlm_cls
+
+
+def _make_guardrail(tlm_cls: mock.MagicMock, score_payload: dict[str, Any]) -> Any:
+    """Construct a CleanlabTlm guardrail whose underlying client returns ``score_payload``."""
+    from any_guardrail.guardrails.cleanlab_tlm.cleanlab_tlm import CleanlabTlm
+
+    tlm_instance = mock.MagicMock()
+    tlm_instance.get_trustworthiness_score.return_value = score_payload
+    tlm_cls.return_value = tlm_instance
+    return CleanlabTlm(api_key="fake-key")
+
+
+def test_high_trust_score_above_threshold_is_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A trustworthiness score above the default threshold should yield ``valid=True``."""
+    tlm_cls = _install_fake_cleanlab_tlm(monkeypatch)
+    guardrail = _make_guardrail(
+        tlm_cls,
+        {"trustworthiness_score": 0.9, "log": {"explanation": "Looks solid."}},
+    )
+
+    result = guardrail.validate(prompt="What is 2+2?", response="4")
+
+    assert isinstance(result, GuardrailOutput)
+    assert result.valid is True
+    assert result.score == pytest.approx(0.9)
+    assert result.explanation is not None
+    assert result.explanation["trustworthiness_score"] == pytest.approx(0.9)
+    assert result.explanation["explanation"] == "Looks solid."
+
+
+def test_low_trust_score_below_threshold_is_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A trustworthiness score below the default threshold should yield ``valid=False``."""
+    tlm_cls = _install_fake_cleanlab_tlm(monkeypatch)
+    guardrail = _make_guardrail(
+        tlm_cls,
+        {"trustworthiness_score": 0.4, "log": {"explanation": "Uncertain."}},
+    )
+
+    result = guardrail.validate(prompt="What is 2+2?", response="5")
+
+    assert isinstance(result, GuardrailOutput)
+    assert result.valid is False
+    assert result.score == pytest.approx(0.4)
+    assert result.explanation is not None
+    assert result.explanation["trustworthiness_score"] == pytest.approx(0.4)
+
+
+def test_custom_threshold_is_respected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A score below an explicit, stricter threshold should yield ``valid=False``."""
+    tlm_cls = _install_fake_cleanlab_tlm(monkeypatch)
+    guardrail = _make_guardrail(
+        tlm_cls,
+        {"trustworthiness_score": 0.9, "log": {}},
+    )
+
+    result = guardrail.validate(prompt="Q", response="A", threshold=0.95)
+
+    assert isinstance(result, GuardrailOutput)
+    assert result.valid is False
+    assert result.score == pytest.approx(0.9)
+
+
+def test_api_key_from_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Constructor should fall back to ``CLEANLAB_TLM_API_KEY`` when ``api_key`` is omitted."""
+    tlm_cls = _install_fake_cleanlab_tlm(monkeypatch)
+    tlm_cls.return_value = mock.MagicMock()
+    monkeypatch.setenv("CLEANLAB_TLM_API_KEY", "env-key-123")
+
+    from any_guardrail.guardrails.cleanlab_tlm.cleanlab_tlm import CleanlabTlm
+
+    guardrail = CleanlabTlm()
+
+    assert guardrail.api_key == "env-key-123"
+    # TLM client should have been instantiated with the env-var key.
+    _, kwargs = tlm_cls.call_args
+    assert kwargs["api_key"] == "env-key-123"
+
+
+def test_missing_api_key_raises_informative_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Constructor should raise ``ValueError`` mentioning the env var when no key is available."""
+    _install_fake_cleanlab_tlm(monkeypatch)
+    monkeypatch.delenv("CLEANLAB_TLM_API_KEY", raising=False)
+
+    from any_guardrail.guardrails.cleanlab_tlm.cleanlab_tlm import CleanlabTlm
+
+    with pytest.raises(ValueError, match="CLEANLAB_TLM_API_KEY"):
+        CleanlabTlm()
+
+
+def test_invalid_model_id_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Passing an unknown ``model_id`` should raise ``ValueError``."""
+    _install_fake_cleanlab_tlm(monkeypatch)
+
+    from any_guardrail.guardrails.cleanlab_tlm.cleanlab_tlm import CleanlabTlm
+
+    with pytest.raises(ValueError, match="Only supports"):
+        CleanlabTlm(model_id="not-a-real-model", api_key="fake")
+
+
+def test_get_trustworthiness_score_called_with_prompt_and_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``validate`` should forward its arguments to the underlying TLM client."""
+    tlm_cls = _install_fake_cleanlab_tlm(monkeypatch)
+    guardrail = _make_guardrail(
+        tlm_cls,
+        {"trustworthiness_score": 0.8, "log": {}},
+    )
+
+    guardrail.validate(prompt="my prompt", response="my response")
+
+    guardrail.tlm.get_trustworthiness_score.assert_called_once_with(
+        prompt="my prompt",
+        response="my response",
+    )


### PR DESCRIPTION
## Summary
Adds `CleanlabTlm` guardrail wrapping Cleanlab's [Trustworthy Language Model](https://help.cleanlab.ai/tlm/) — a hosted scoring service that returns a trustworthiness score for any (prompt, response) pair. Designed for hallucination detection in RAG and agent pipelines.

## Research backing
- Chen & Mueller, [Quantifying Uncertainty in Answers from any Language Model and Enhancing their Trustworthiness](https://aclanthology.org/2024.acl-long.283/) (ACL 2024) — BSDetector method underlying TLM.
- [Cleanlab agent-architecture hallucination benchmark](https://cleanlab.ai/blog/agent-tlm-hallucination-benchmarking/) — trust scores detect incorrect RAG responses with ~3× the precision of RAGAS/groundedness baselines.

## Why commercial-only
TLM combines black-box intrinsic + extrinsic uncertainty signals over arbitrary LLM APIs as a hosted scoring service. No OSS package replicates the full pipeline (the underlying BSDetector method is published, but the production scoring service with its calibration and multi-signal fusion is closed-source).

## Access
- Free $5 of credits at signup.
- Signup: https://tlm.cleanlab.ai/ → API key in dashboard.
- Env var: `CLEANLAB_TLM_API_KEY`.

## Triage notes
- **Not yet integration-tested** — awaiting API key procurement.
- Adds new optional extra: `pip install 'any-guardrail[cleanlab-tlm]'`.
- **Output semantics inverted**: higher score = more trustworthy = more valid. Default `threshold=0.7`.
- Inherits from `Guardrail` (not `ThreeStageGuardrail`) because `validate(prompt, response)` doesn't match the standard `(input_text)` signature.

## Test plan
- [ ] Provision a Cleanlab TLM API key
- [ ] Add integration test under `tests/integration/` with `@pytest.mark.e2e` using a known hallucinated response
- [ ] Cookbook entry showing RAG-grounding use case

🤖 Generated with [Claude Code](https://claude.com/claude-code)