### PR TITLE
fix(guardrails): enforce causal-LM loader for ShieldGemma/GraniteGuardian/LlamaGuard

### DIFF
--- a/src/any_guardrail/guardrails/granite_guardian/granite_guardian.py
+++ b/src/any_guardrail/guardrails/granite_guardian/granite_guardian.py
@@ -159,20 +159,29 @@ class GraniteGuardian(ThreeStageGuardrail[GraniteGuardianPreprocessData, Granite
         self.criteria = criteria
         self.think = think
 
+        # Lazy-import transformers so users on `any-guardrail[llamafile]`
+        # (without the huggingface extra) can construct GraniteGuardian with
+        # a non-HF provider (e.g. LlamafileProvider) without paying the import
+        # cost or hitting ImportError at module load time.
+        load_kwargs: AnyDict = {}
         if provider is not None:
             self.provider = provider
+            if isinstance(self.provider, HuggingFaceProvider):
+                # Granite Guardian is a causal LM. A default-constructed
+                # HuggingFaceProvider targets AutoModelForSequenceClassification,
+                # which would silently load the wrong head. Enforce the right
+                # classes for this load (does not mutate provider state).
+                from transformers import AutoModelForCausalLM, AutoTokenizer
+
+                load_kwargs = {"model_class": AutoModelForCausalLM, "tokenizer_class": AutoTokenizer}
         else:
-            # Lazy-import transformers so users on `any-guardrail[llamafile]`
-            # (without the huggingface extra) can construct GraniteGuardian
-            # with a non-HF provider without paying the import cost or
-            # hitting ImportError at module load time.
             from transformers import AutoModelForCausalLM, AutoTokenizer
 
             self.provider = HuggingFaceProvider(
                 model_class=AutoModelForCausalLM,
                 tokenizer_class=AutoTokenizer,
             )
-        self.provider.load_model(self.model_id)
+        self.provider.load_model(self.model_id, **load_kwargs)
 
     def validate(  # type: ignore[override]
         self,

--- a/src/any_guardrail/guardrails/llama_guard/llama_guard.py
+++ b/src/any_guardrail/guardrails/llama_guard/llama_guard.py
@@ -48,13 +48,31 @@ class LlamaGuard(ThreeStageGuardrail[LlamaGuardPreprocessData, LlamaGuardInferen
             msg = f"Unsupported model_id: {self.model_id}"
             raise ValueError(msg)
 
+        # Lazy-import transformers so users on `any-guardrail[llamafile]`
+        # (without the huggingface extra) can construct LlamaGuard with a
+        # non-HF provider (e.g. LlamafileProvider) without paying the import
+        # cost or hitting ImportError at module load time.
+        load_kwargs: AnyDict = {}
         if provider is not None:
             self.provider = provider
+            if isinstance(self.provider, HuggingFaceProvider):
+                # Llama Guard is a causal LM (or multimodal seq2seq for v4). A
+                # default-constructed HuggingFaceProvider targets
+                # AutoModelForSequenceClassification, which would silently load
+                # the wrong head. Enforce the right classes for this load
+                # (does not mutate provider state).
+                if self._is_version_4:
+                    from transformers import AutoProcessor, Llama4ForConditionalGeneration
+
+                    load_kwargs = {
+                        "model_class": Llama4ForConditionalGeneration,
+                        "tokenizer_class": AutoProcessor,
+                    }
+                else:
+                    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+                    load_kwargs = {"model_class": AutoModelForCausalLM, "tokenizer_class": AutoTokenizer}
         else:
-            # Lazy-import transformers so users on `any-guardrail[llamafile]`
-            # (without the huggingface extra) can construct LlamaGuard with
-            # a non-HF provider without paying the import cost or hitting
-            # ImportError at module load time.
             from transformers import (
                 AutoModelForCausalLM,
                 AutoProcessor,
@@ -72,7 +90,7 @@ class LlamaGuard(ThreeStageGuardrail[LlamaGuardPreprocessData, LlamaGuardInferen
                     model_class=AutoModelForCausalLM,
                     tokenizer_class=AutoTokenizer,
                 )
-        self.provider.load_model(self.model_id)
+        self.provider.load_model(self.model_id, **load_kwargs)
 
     def _build_conversation(self, input_text: str, output_text: str | None) -> list[AnyDict]:
         """Shape the chat conversation per model variant."""

--- a/src/any_guardrail/guardrails/shield_gemma/shield_gemma.py
+++ b/src/any_guardrail/guardrails/shield_gemma/shield_gemma.py
@@ -8,6 +8,7 @@ from any_guardrail.guardrails.utils import default
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.types import (
+    AnyDict,
     BinaryScoreOutput,
     GuardrailPreprocessOutput,
     StandardInferenceOutput,
@@ -58,11 +59,20 @@ class ShieldGemma(StandardGuardrail):
         self.policy = policy
         self.system_prompt = SYSTEM_PROMPT_SHIELD_GEMMA
         self.threshold = threshold
+        load_kwargs: AnyDict = {}
         if provider is not None:
             self.provider = provider
+            if isinstance(self.provider, HuggingFaceProvider):
+                # ShieldGemma is a causal LM. A default-constructed
+                # HuggingFaceProvider targets AutoModelForSequenceClassification,
+                # which would load Gemma2ForSequenceClassification — the
+                # checkpoint has no classification head, so score.weight is
+                # randomly initialized and _post_processing later crashes on
+                # 2D logits. Enforce the right classes for this load.
+                load_kwargs = {"model_class": AutoModelForCausalLM, "tokenizer_class": AutoTokenizer}
         else:
             self.provider = HuggingFaceProvider(model_class=AutoModelForCausalLM, tokenizer_class=AutoTokenizer)
-        self.provider.load_model(self.model_id)
+        self.provider.load_model(self.model_id, **load_kwargs)
 
     def _pre_processing(self, input_text: str) -> StandardPreprocessOutput:
         formatted_prompt = self.system_prompt.format(user_prompt=input_text, safety_policy=self.policy)

--- a/src/any_guardrail/guardrails/shield_gemma/shield_gemma.py
+++ b/src/any_guardrail/guardrails/shield_gemma/shield_gemma.py
@@ -1,8 +1,5 @@
 from typing import ClassVar
 
-from torch.nn.functional import softmax
-from transformers import AutoModelForCausalLM, AutoTokenizer
-
 from any_guardrail.base import GuardrailOutput, StandardGuardrail
 from any_guardrail.guardrails.utils import default
 from any_guardrail.providers.base import StandardProvider
@@ -59,6 +56,11 @@ class ShieldGemma(StandardGuardrail):
         self.policy = policy
         self.system_prompt = SYSTEM_PROMPT_SHIELD_GEMMA
         self.threshold = threshold
+        # Lazy-import transformers so importing ShieldGemma does not require
+        # the huggingface extra. A caller could supply a non-HF provider that
+        # returns torch tensors from infer() — the transformers classes are
+        # only needed when the provider is a HuggingFaceProvider (or when we
+        # construct one ourselves).
         load_kwargs: AnyDict = {}
         if provider is not None:
             self.provider = provider
@@ -69,8 +71,12 @@ class ShieldGemma(StandardGuardrail):
                 # checkpoint has no classification head, so score.weight is
                 # randomly initialized and _post_processing later crashes on
                 # 2D logits. Enforce the right classes for this load.
+                from transformers import AutoModelForCausalLM, AutoTokenizer
+
                 load_kwargs = {"model_class": AutoModelForCausalLM, "tokenizer_class": AutoTokenizer}
         else:
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+
             self.provider = HuggingFaceProvider(model_class=AutoModelForCausalLM, tokenizer_class=AutoTokenizer)
         self.provider.load_model(self.model_id, **load_kwargs)
 
@@ -86,6 +92,12 @@ class ShieldGemma(StandardGuardrail):
         return self.provider.infer(model_inputs)
 
     def _post_processing(self, model_outputs: StandardInferenceOutput) -> BinaryScoreOutput:
+        # Lazy-import torch so importing ShieldGemma does not require the
+        # huggingface extra at module load. ShieldGemma still needs torch
+        # at validate() time to slice the causal-LM logits, but a user who
+        # never calls validate() can import the class freely.
+        from torch.nn.functional import softmax
+
         logits = model_outputs.data["logits"]
         vocab = self.provider.tokenizer.get_vocab()  # type: ignore[attr-defined]
         selected_logits = logits[0, -1, [vocab["Yes"], vocab["No"]]]

--- a/src/any_guardrail/providers/huggingface.py
+++ b/src/any_guardrail/providers/huggingface.py
@@ -137,19 +137,30 @@ class HuggingFaceProvider(Provider[AnyDict, AnyDict]):
         Args:
             model_id: The HuggingFace model identifier.
             **kwargs: Additional keyword arguments passed to the model's
-                ``from_pretrained`` (override provider-level defaults).
+                ``from_pretrained`` (override provider-level defaults). Two reserved
+                names are popped before forwarding:
+
+                - ``model_class``: override the model class used for this load.
+                  Lets a decoder-LM guardrail (e.g. ShieldGemma) enforce
+                  ``AutoModelForCausalLM`` even when the caller supplied a
+                  default-constructed ``HuggingFaceProvider`` configured for
+                  sequence classification. ``self.model_class`` is not mutated.
+                - ``tokenizer_class``: same idea for the tokenizer class (e.g.
+                  ``AutoProcessor`` for Llama Guard 4).
 
         """
+        model_class = kwargs.pop("model_class", None) or self.model_class
+        tokenizer_class = kwargs.pop("tokenizer_class", None) or self.tokenizer_class
         common_kwargs = self._build_from_pretrained_kwargs()
         model_load_kwargs: AnyDict = {**common_kwargs, **self.model_kwargs}
         if self.torch_dtype is not None:
             model_load_kwargs["torch_dtype"] = self.torch_dtype
         model_load_kwargs.update(kwargs)
-        self.model = self.model_class.from_pretrained(model_id, **model_load_kwargs)  # type: ignore[attr-defined]
+        self.model = model_class.from_pretrained(model_id, **model_load_kwargs)  # type: ignore[union-attr]
         if self.device is not None:
             self.model = self.model.to(self.device)
         tokenizer_id = self.tokenizer_id or model_id
-        self.tokenizer = self.tokenizer_class.from_pretrained(tokenizer_id, **common_kwargs)  # type: ignore[attr-defined]
+        self.tokenizer = tokenizer_class.from_pretrained(tokenizer_id, **common_kwargs)  # type: ignore[union-attr]
 
     def pre_process(self, input_text: str | list[str], **kwargs: Any) -> GuardrailPreprocessOutput[AnyDict]:
         """Tokenize input text for model consumption.

--- a/tests/unit/test_unit_granite_guardian.py
+++ b/tests/unit/test_unit_granite_guardian.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -272,6 +272,50 @@ def test_validate_raises_on_non_chat_capable_provider(guardian_instance: Granite
 
     with pytest.raises(NotImplementedError, match="generate_chat"):
         guardian_instance.validate("test input")
+
+
+def test_user_supplied_default_hf_provider_loaded_with_causal_lm() -> None:
+    """Regression: a default-constructed HuggingFaceProvider must still load as a causal LM.
+
+    Granite Guardian is a causal LM. If a user passes ``HuggingFaceProvider()``
+    (whose default ``model_class`` is ``AutoModelForSequenceClassification``),
+    GraniteGuardian.__init__ must override the loader for this call so the
+    causal-LM head is loaded — not the missing classification head.
+    """
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    from any_guardrail.providers.huggingface import HuggingFaceProvider
+
+    shared_provider = HuggingFaceProvider()
+    assert shared_provider.model_class is not AutoModelForCausalLM  # sanity: default is seq-classification
+
+    with patch.object(HuggingFaceProvider, "load_model") as mock_load:
+        GraniteGuardian(provider=shared_provider, criteria=GraniteGuardianRisk.HARM)
+
+    mock_load.assert_called_once()
+    _, load_kwargs = mock_load.call_args
+    assert load_kwargs["model_class"] is AutoModelForCausalLM
+    assert load_kwargs["tokenizer_class"] is AutoTokenizer
+    # The provider's stored defaults are not mutated.
+    assert shared_provider.model_class is not AutoModelForCausalLM
+
+
+def test_no_provider_path_constructs_provider_with_causal_lm() -> None:
+    """When no provider is supplied, GraniteGuardian builds an HF provider configured for causal LM.
+
+    This is the existing default behavior; it should not regress when the
+    user-supplied-provider path is hardened.
+    """
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    from any_guardrail.providers.huggingface import HuggingFaceProvider
+
+    with patch.object(HuggingFaceProvider, "load_model"):
+        guardian = GraniteGuardian(criteria=GraniteGuardianRisk.HARM)
+
+    assert isinstance(guardian.provider, HuggingFaceProvider)
+    assert guardian.provider.model_class is AutoModelForCausalLM
+    assert guardian.provider.tokenizer_class is AutoTokenizer
 
 
 def test_risk_constants_are_nonempty_strings() -> None:

--- a/tests/unit/test_unit_huggingface_provider.py
+++ b/tests/unit/test_unit_huggingface_provider.py
@@ -105,6 +105,51 @@ def test_load_model_kwargs_override_provider_defaults(mock_classes: tuple[MagicM
     assert model_kwargs["device_map"] == "cuda:0"
 
 
+def test_load_model_model_class_override_used_and_self_unchanged(mock_classes: tuple[MagicMock, MagicMock]) -> None:
+    """``model_class`` kwarg overrides the provider's default for this call only.
+
+    Lets decoder-LM guardrails (ShieldGemma, GraniteGuardian, LlamaGuard) enforce
+    the right loader even when handed a default-constructed (sequence-classification)
+    HuggingFaceProvider. The provider's stored ``model_class`` must not be mutated.
+    """
+    default_model_class, tokenizer_class = mock_classes
+    override_model_class = MagicMock()
+    override_model_class.from_pretrained.return_value = MagicMock()
+
+    provider = HuggingFaceProvider(model_class=default_model_class, tokenizer_class=tokenizer_class)
+    provider.load_model("dummy-id", model_class=override_model_class)
+
+    override_model_class.from_pretrained.assert_called_once()
+    default_model_class.from_pretrained.assert_not_called()
+    # ``model_class`` kwarg must not leak into from_pretrained as a regular kwarg.
+    _, model_kwargs = override_model_class.from_pretrained.call_args
+    assert "model_class" not in model_kwargs
+    # The provider's default is preserved for subsequent loads.
+    assert provider.model_class is default_model_class
+
+
+def test_load_model_tokenizer_class_override_used_for_this_call_only(
+    mock_classes: tuple[MagicMock, MagicMock],
+) -> None:
+    """``tokenizer_class`` kwarg overrides the provider's default for this call only.
+
+    Needed for Llama Guard 4, which uses ``AutoProcessor`` instead of
+    ``AutoTokenizer``. The provider's stored ``tokenizer_class`` must not be mutated.
+    """
+    model_class, default_tokenizer_class = mock_classes
+    override_tokenizer_class = MagicMock()
+    override_tokenizer_class.from_pretrained.return_value = MagicMock()
+
+    provider = HuggingFaceProvider(model_class=model_class, tokenizer_class=default_tokenizer_class)
+    provider.load_model("dummy-id", tokenizer_class=override_tokenizer_class)
+
+    override_tokenizer_class.from_pretrained.assert_called_once()
+    default_tokenizer_class.from_pretrained.assert_not_called()
+    _, tokenizer_kwargs = override_tokenizer_class.from_pretrained.call_args
+    assert "tokenizer_class" not in tokenizer_kwargs
+    assert provider.tokenizer_class is default_tokenizer_class
+
+
 def test_tokenizer_kwargs_applied_per_call() -> None:
     """``tokenizer_kwargs`` are applied to every ``pre_process`` invocation."""
     tokenizer = MagicMock(return_value={"input_ids": [[1, 2, 3]]})

--- a/tests/unit/test_unit_llama_guard.py
+++ b/tests/unit/test_unit_llama_guard.py
@@ -1,0 +1,66 @@
+from unittest.mock import patch
+
+from transformers import (
+    AutoModelForCausalLM,
+    AutoProcessor,
+    AutoTokenizer,
+    Llama4ForConditionalGeneration,
+)
+
+from any_guardrail.guardrails.llama_guard import LlamaGuard
+from any_guardrail.providers.huggingface import HuggingFaceProvider
+
+
+def test_v3_user_supplied_default_hf_provider_loaded_with_causal_lm() -> None:
+    """Llama Guard 3 with a default HuggingFaceProvider must load via ``AutoModelForCausalLM``.
+
+    Otherwise the seq-classification default would silently load the wrong
+    head and corrupt downstream chat-template generation.
+    """
+    shared_provider = HuggingFaceProvider()
+
+    with patch.object(HuggingFaceProvider, "load_model") as mock_load:
+        LlamaGuard(model_id="meta-llama/Llama-Guard-3-1B", provider=shared_provider)
+
+    mock_load.assert_called_once()
+    _, load_kwargs = mock_load.call_args
+    assert load_kwargs["model_class"] is AutoModelForCausalLM
+    assert load_kwargs["tokenizer_class"] is AutoTokenizer
+    assert shared_provider.model_class is not AutoModelForCausalLM
+
+
+def test_v4_user_supplied_default_hf_provider_loaded_with_llama4_conditional() -> None:
+    """Llama Guard 4 with a default HuggingFaceProvider must load via ``Llama4ForConditionalGeneration``.
+
+    The v4 multimodal variant needs ``AutoProcessor`` (not ``AutoTokenizer``);
+    the default seq-classification provider would break both.
+    """
+    shared_provider = HuggingFaceProvider()
+
+    with patch.object(HuggingFaceProvider, "load_model") as mock_load:
+        LlamaGuard(model_id="meta-llama/Llama-Guard-4-12B", provider=shared_provider)
+
+    mock_load.assert_called_once()
+    _, load_kwargs = mock_load.call_args
+    assert load_kwargs["model_class"] is Llama4ForConditionalGeneration
+    assert load_kwargs["tokenizer_class"] is AutoProcessor
+
+
+def test_v3_no_provider_path_constructs_provider_with_causal_lm() -> None:
+    """When no provider is supplied, v3 builds a HuggingFaceProvider with the right causal-LM classes."""
+    with patch.object(HuggingFaceProvider, "load_model"):
+        guardrail = LlamaGuard(model_id="meta-llama/Llama-Guard-3-1B")
+
+    assert isinstance(guardrail.provider, HuggingFaceProvider)
+    assert guardrail.provider.model_class is AutoModelForCausalLM
+    assert guardrail.provider.tokenizer_class is AutoTokenizer
+
+
+def test_v4_no_provider_path_constructs_provider_with_llama4_conditional() -> None:
+    """When no provider is supplied, v4 builds a HuggingFaceProvider with ``Llama4ForConditionalGeneration``."""
+    with patch.object(HuggingFaceProvider, "load_model"):
+        guardrail = LlamaGuard(model_id="meta-llama/Llama-Guard-4-12B")
+
+    assert isinstance(guardrail.provider, HuggingFaceProvider)
+    assert guardrail.provider.model_class is Llama4ForConditionalGeneration
+    assert guardrail.provider.tokenizer_class is AutoProcessor

--- a/tests/unit/test_unit_shield_gemma.py
+++ b/tests/unit/test_unit_shield_gemma.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from any_guardrail.guardrails.shield_gemma import ShieldGemma
+from any_guardrail.providers.huggingface import HuggingFaceProvider
+
+
+def test_user_supplied_default_hf_provider_loaded_with_causal_lm() -> None:
+    """Regression: a default-constructed HuggingFaceProvider must still load as a causal LM.
+
+    A user app that shares one ``HuggingFaceProvider()`` (default
+    ``model_class=AutoModelForSequenceClassification``) across multiple
+    guardrails used to silently load ShieldGemma as
+    ``Gemma2ForSequenceClassification`` — the checkpoint has no
+    ``score.weight``, so it was randomly initialized and ``_post_processing``
+    later crashed with ``IndexError: too many indices for array`` (2D logits
+    instead of the expected 3D causal-LM logits).
+
+    ShieldGemma must now override the loader for this load so the causal-LM
+    head is loaded, without mutating the provider's stored defaults.
+    """
+    shared_provider = HuggingFaceProvider()
+    assert shared_provider.model_class is not AutoModelForCausalLM  # sanity: default is seq-classification
+
+    with patch.object(HuggingFaceProvider, "load_model") as mock_load:
+        ShieldGemma(policy="Do not provide harmful content", provider=shared_provider)
+
+    mock_load.assert_called_once()
+    _, load_kwargs = mock_load.call_args
+    assert load_kwargs["model_class"] is AutoModelForCausalLM
+    assert load_kwargs["tokenizer_class"] is AutoTokenizer
+    # The provider's stored defaults are not mutated.
+    assert shared_provider.model_class is not AutoModelForCausalLM
+
+
+def test_no_provider_path_constructs_provider_with_causal_lm() -> None:
+    """When no provider is supplied, ShieldGemma builds an HF provider configured for causal LM."""
+    with patch.object(HuggingFaceProvider, "load_model"):
+        guardrail = ShieldGemma(policy="Do not provide harmful content")
+
+    assert isinstance(guardrail.provider, HuggingFaceProvider)
+    assert guardrail.provider.model_class is AutoModelForCausalLM
+    assert guardrail.provider.tokenizer_class is AutoTokenizer


### PR DESCRIPTION
## Summary

A shared `HuggingFaceProvider()` (whose default `model_class` is `AutoModelForSequenceClassification`) passed to a decoder-LM guardrail silently loaded the wrong head. The Gemma/Granite/Llama-Guard checkpoints have no `score.weight`, so the classification head was randomly initialized, and `_post_processing` later crashed with:

```
[transformers] Gemma2ForSequenceClassification LOAD REPORT from: google/shieldgemma-2b
score.weight | MISSING
...
IndexError: too many indices for array: array is 2-dimensional, but 3 were indexed
```

This happened in production when a user shared one `HuggingFaceProvider` across DuoGuard (sequence classification) and ShieldGemma (causal LM).

## Fix

- Add per-call `model_class` / `tokenizer_class` overrides to `HuggingFaceProvider.load_model()`. They override `self.model_class` / `self.tokenizer_class` for that call only — provider state is not mutated.
- `ShieldGemma`, `GraniteGuardian`, and `LlamaGuard` now pass the right pair to `load_model()` whenever the supplied provider is a `HuggingFaceProvider`, regardless of how it was constructed.
- Lazy `from transformers import ...` is preserved (only happens inside the `isinstance(provider, HuggingFaceProvider)` branch), so users on `[llamafile]`-only installs without `transformers` can still pass a non-HF provider.
- `LlamaGuard` 4 routes through `Llama4ForConditionalGeneration` + `AutoProcessor`.

## Test plan

- [x] `pytest tests/unit` — 143 passed (4 new tests added: provider overrides, plus regression tests for ShieldGemma, GraniteGuardian, and LlamaGuard v3+v4).
- [x] `pre-commit run --all-files` — ruff, mypy strict, codespell, nbstripout all pass.
- [ ] Manual repro of the user's crash (not run here, requires a ~5 GB model download):
      ```python
      from any_guardrail.guardrails.shield_gemma import ShieldGemma
      from any_guardrail.providers.huggingface import HuggingFaceProvider
      shared = HuggingFaceProvider()  # default = sequence classification
      g = ShieldGemma(policy="...", provider=shared)
      g.validate("What is the weather like today?")  # must not crash; no MISSING weights warning
      ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)