### PR TITLE
feat(providers): support external Llamafile/Encoderfile servers via base_url

### DIFF
--- a/src/any_guardrail/providers/encoderfile.py
+++ b/src/any_guardrail/providers/encoderfile.py
@@ -104,22 +104,32 @@ class EncoderfileProvider(Provider[AnyDict, AnyDict]):
         binary_path: Path to a pre-built ``.encoderfile``. If omitted, the
             platform-appropriate artifact is auto-downloaded from
             ``mozilla-ai/encoderfile`` using the model_id passed to
-            ``load_model``.
+            ``load_model``. Mutually exclusive with ``base_url``.
+        base_url: External-server mode. Point at an encoderfile server you spun
+            up yourself (e.g. ``"http://localhost:9999"``). When set, the
+            provider skips download + subprocess spawn entirely; ``load_model``
+            only polls the server for readiness, and ``close()`` is a no-op.
+            Mutually exclusive with ``binary_path``, ``port``, and a
+            non-default ``encoderfile_repo``. Must start with ``http://`` or
+            ``https://``.
         port: TCP port to bind the encoderfile HTTP server. Defaults to a
-            kernel-chosen free port.
+            kernel-chosen free port. Mutually exclusive with ``base_url``.
         host: Bind address. Defaults to ``"127.0.0.1"``.
-        startup_timeout: Seconds to wait for the server to become ready.
+        startup_timeout: Seconds to wait for the server to become ready. Also
+            applies to external-server readiness polling.
         request_timeout: Per-request timeout for ``/predict`` calls.
         cache_dir: Directory passed to ``hf_hub_download`` for auto-downloaded
             binaries.
         encoderfile_repo: Override the source HF repo. Defaults to
-            ``mozilla-ai/encoderfile``.
+            ``mozilla-ai/encoderfile``. Mutually exclusive with ``base_url``
+            when set to a non-default value.
 
     """
 
     def __init__(
         self,
         binary_path: str | None = None,
+        base_url: str | None = None,
         port: int | None = None,
         host: str = "127.0.0.1",
         startup_timeout: float = 60.0,
@@ -128,7 +138,9 @@ class EncoderfileProvider(Provider[AnyDict, AnyDict]):
         encoderfile_repo: str = _DEFAULT_ENCODERFILE_REPO,
     ) -> None:
         """Initialize the encoderfile provider."""
-        if binary_path is None and MISSING_PACKAGES_ERROR is not None:
+        self._external_mode = base_url is not None
+
+        if not self._external_mode and binary_path is None and MISSING_PACKAGES_ERROR is not None:
             msg = (
                 "Missing packages for EncoderfileProvider auto-download. "
                 "You can try `pip install 'any-guardrail[encoderfile]'`, or pass a local "
@@ -151,6 +163,22 @@ class EncoderfileProvider(Provider[AnyDict, AnyDict]):
         # access ``provider.model`` for compatibility). It carries the binary
         # path and a labels list when known.
         self.model: AnyDict = {}
+
+        if self._external_mode:
+            assert base_url is not None  # for type narrowing; _external_mode == (base_url is not None)
+            if not base_url.startswith(("http://", "https://")):
+                msg = f"base_url must start with http:// or https://, got {base_url!r}"
+                raise ValueError(msg)
+            conflicts: AnyDict = {"binary_path": binary_path, "port": port}
+            # ``encoderfile_repo`` has a non-None default, so only flag it when
+            # the user actively overrode it.
+            if encoderfile_repo != _DEFAULT_ENCODERFILE_REPO:
+                conflicts["encoderfile_repo"] = encoderfile_repo
+            bad = sorted(k for k, v in conflicts.items() if v is not None)
+            if bad:
+                msg = f"base_url is mutually exclusive with: {bad}"
+                raise ValueError(msg)
+            self.base_url = base_url.rstrip("/")
 
         atexit.register(self.close)
 
@@ -229,13 +257,24 @@ class EncoderfileProvider(Provider[AnyDict, AnyDict]):
         ``port=`` constructor argument, no retry: surface the failure
         immediately.
 
+        In external-server mode (``base_url`` supplied to the constructor),
+        the binary lookup and subprocess spawn are skipped — the provider
+        only polls the user's server for readiness.
+
         Args:
             model_id: any-guardrail model identifier. Used to look up the right
-                encoderfile artifact when auto-downloading.
+                encoderfile artifact when auto-downloading. In external-server
+                mode this is recorded as metadata only.
             **kwargs: Ignored. Present to match the Provider signature.
 
         """
         del kwargs  # not used; the binary owns all model state.
+
+        if self._external_mode:
+            self.model_id = model_id
+            self.model = {"model_id": model_id, "base_url": self.base_url}
+            self._wait_ready()
+            return
 
         # If a previous binary is still running (e.g. caller is reusing the
         # provider with a new model_id), tear it down first so we don't leak
@@ -328,7 +367,11 @@ class EncoderfileProvider(Provider[AnyDict, AnyDict]):
         )
 
     def close(self) -> None:
-        """Terminate the encoderfile subprocess. Idempotent."""
+        """Terminate the encoderfile subprocess. Idempotent.
+
+        In external-server mode there is no subprocess to terminate and
+        ``self.base_url`` is preserved so the provider stays reusable.
+        """
         if self.process is None:
             return
         if self.process.poll() is None:
@@ -339,7 +382,8 @@ class EncoderfileProvider(Provider[AnyDict, AnyDict]):
                 self.process.kill()
                 self.process.wait()
         self.process = None
-        self.base_url = None
+        if not self._external_mode:
+            self.base_url = None
 
     def __enter__(self) -> Self:
         """Enter the context manager. Returns ``self`` so the binding works as expected.

--- a/src/any_guardrail/providers/llamafile.py
+++ b/src/any_guardrail/providers/llamafile.py
@@ -86,26 +86,37 @@ class LlamafileProvider(Provider[AnyDict, AnyDict]):
             if both were supplied, otherwise by looking up the ``model_id``
             passed to ``load_model`` in the curated
             :data:`~any_guardrail.providers._llamafile_artifacts.LLAMAFILE_ARTIFACTS`
-            map.
+            map. Mutually exclusive with ``base_url``.
         repo_id: Power-user override for the HuggingFace repo containing the
-            llamafile. Used together with ``filename``.
+            llamafile. Used together with ``filename``. Mutually exclusive with
+            ``base_url``.
         filename: Power-user override for the artifact filename inside
-            ``repo_id``. Used together with ``repo_id``.
+            ``repo_id``. Used together with ``repo_id``. Mutually exclusive with
+            ``base_url``.
+        base_url: External-server mode. Point at a llamafile server you spun up
+            yourself (e.g. ``"http://localhost:9999"``). When set, the provider
+            skips download + subprocess spawn entirely; ``load_model`` only polls
+            the server for readiness, and ``close()`` is a no-op. Mutually
+            exclusive with ``binary_path``, ``repo_id``/``filename``, ``port``,
+            ``n_gpu_layers``, ``context_size``, and ``extra_args``. Must start
+            with ``http://`` or ``https://``.
         port: TCP port to bind the llamafile HTTP server. Defaults to a
-            kernel-chosen free port.
+            kernel-chosen free port. Mutually exclusive with ``base_url``.
         host: Bind address. Defaults to ``"127.0.0.1"``.
         startup_timeout: Seconds to wait for the server to become ready.
             Llamafiles can take ~30s to memory-map and warm up; the default
-            is generous.
+            is generous. Also applies to external-server readiness polling.
         request_timeout: Per-request timeout for ``/v1/chat/completions``.
         cache_dir: Directory passed to ``hf_hub_download`` for auto-downloaded
             binaries.
         n_gpu_layers: Optional number of model layers to offload to GPU. Passed
             as ``--n-gpu-layers``. ``None`` (default) lets llamafile decide.
+            Mutually exclusive with ``base_url``.
         context_size: Optional context window size. Passed as ``--ctx-size``.
+            Mutually exclusive with ``base_url``.
         extra_args: Optional list of additional command-line arguments appended
             after the standard server flags. Use this for advanced llamafile
-            flags not surfaced above.
+            flags not surfaced above. Mutually exclusive with ``base_url``.
 
     """
 
@@ -114,6 +125,7 @@ class LlamafileProvider(Provider[AnyDict, AnyDict]):
         binary_path: str | None = None,
         repo_id: str | None = None,
         filename: str | None = None,
+        base_url: str | None = None,
         port: int | None = None,
         host: str = "127.0.0.1",
         startup_timeout: float = 120.0,
@@ -124,7 +136,9 @@ class LlamafileProvider(Provider[AnyDict, AnyDict]):
         extra_args: list[str] | None = None,
     ) -> None:
         """Initialize the llamafile provider."""
-        if binary_path is None and MISSING_PACKAGES_ERROR is not None:
+        self._external_mode = base_url is not None
+
+        if not self._external_mode and binary_path is None and MISSING_PACKAGES_ERROR is not None:
             msg = (
                 "Missing packages for LlamafileProvider auto-download. "
                 "You can try `pip install 'any-guardrail[llamafile]'`, or pass a local "
@@ -154,6 +168,26 @@ class LlamafileProvider(Provider[AnyDict, AnyDict]):
         # ``model`` is kept for parity with HuggingFaceProvider so callers that
         # introspect ``provider.model`` don't crash.
         self.model: AnyDict = {}
+
+        if self._external_mode:
+            assert base_url is not None  # for type narrowing; _external_mode == (base_url is not None)
+            if not base_url.startswith(("http://", "https://")):
+                msg = f"base_url must start with http:// or https://, got {base_url!r}"
+                raise ValueError(msg)
+            conflicts = {
+                "binary_path": binary_path,
+                "repo_id": repo_id,
+                "filename": filename,
+                "port": port,
+                "n_gpu_layers": n_gpu_layers,
+                "context_size": context_size,
+                "extra_args": extra_args,
+            }
+            bad = sorted(k for k, v in conflicts.items() if v is not None)
+            if bad:
+                msg = f"base_url is mutually exclusive with: {bad}"
+                raise ValueError(msg)
+            self.base_url = base_url.rstrip("/")
 
         atexit.register(self.close)
 
@@ -232,14 +266,25 @@ class LlamafileProvider(Provider[AnyDict, AnyDict]):
         ``port=`` constructor argument, no retry: surface the failure
         immediately.
 
+        In external-server mode (``base_url`` supplied to the constructor),
+        the binary lookup and subprocess spawn are skipped — the provider
+        only polls the user's server for readiness.
+
         Args:
             model_id: any-guardrail model identifier. Looked up in
                 :data:`LLAMAFILE_ARTIFACTS` when ``repo_id``/``filename``
-                overrides weren't supplied to the constructor.
+                overrides weren't supplied to the constructor. In
+                external-server mode this is recorded as metadata only.
             **kwargs: Ignored. Present to match the Provider signature.
 
         """
         del kwargs
+
+        if self._external_mode:
+            self.model_id = model_id
+            self.model = {"model_id": model_id, "base_url": self.base_url}
+            self._wait_ready()
+            return
 
         # If a previous binary is still running, tear it down first so we don't
         # leak the subprocess and its port.
@@ -386,7 +431,11 @@ class LlamafileProvider(Provider[AnyDict, AnyDict]):
         )
 
     def close(self) -> None:
-        """Terminate the llamafile subprocess. Idempotent."""
+        """Terminate the llamafile subprocess. Idempotent.
+
+        In external-server mode there is no subprocess to terminate and
+        ``self.base_url`` is preserved so the provider stays reusable.
+        """
         if self.process is None:
             return
         if self.process.poll() is None:
@@ -397,7 +446,8 @@ class LlamafileProvider(Provider[AnyDict, AnyDict]):
                 self.process.kill()
                 self.process.wait()
         self.process = None
-        self.base_url = None
+        if not self._external_mode:
+            self.base_url = None
 
     def __enter__(self) -> Self:
         """Enter the context manager. Returns ``self`` so the binding works as expected.

--- a/tests/unit/test_unit_encoderfile_provider.py
+++ b/tests/unit/test_unit_encoderfile_provider.py
@@ -332,3 +332,97 @@ def test_load_model_gives_up_after_max_bind_race_retries(tmp_path: Any) -> None:
             provider.load_model("ProtectAI/deberta-v3-base-prompt-injection-v2")
 
     assert mock_popen.call_count == EncoderfileProvider._BIND_RACE_RETRIES
+
+
+# ----- external-server mode -----
+
+
+def test_external_mode_skips_subprocess() -> None:
+    """``base_url=`` short-circuits download + spawn; only readiness probe runs."""
+    with (
+        patch("any_guardrail.providers.encoderfile.subprocess.Popen") as mock_popen,
+        patch("any_guardrail.providers.encoderfile.urllib.request.urlopen") as mock_urlopen,
+    ):
+        mock_urlopen.return_value = _stub_response({"results": [], "model_id": "stub"})
+
+        provider = EncoderfileProvider(base_url="http://localhost:9999")
+        provider.load_model("ProtectAI/deberta-v3-base-prompt-injection-v2")
+
+        mock_popen.assert_not_called()
+        probed_urls = [call.args[0].full_url for call in mock_urlopen.call_args_list]
+        assert "http://localhost:9999/predict" in probed_urls
+        assert provider.base_url == "http://localhost:9999"
+        assert provider.process is None
+        assert provider.model_id == "ProtectAI/deberta-v3-base-prompt-injection-v2"
+
+
+def test_external_mode_infer_targets_supplied_url() -> None:
+    """``infer`` POSTs to the user-supplied URL's predict endpoint."""
+    inference_payload = {
+        "results": [
+            {
+                "logits": [0.1, 2.0],
+                "scores": [0.13, 0.87],
+                "predicted_index": 1,
+                "predicted_label": "INJECTION",
+            }
+        ],
+    }
+    with patch("any_guardrail.providers.encoderfile.urllib.request.urlopen") as mock_urlopen:
+        # First call: readiness probe; subsequent: actual predict.
+        mock_urlopen.side_effect = [
+            _stub_response({"results": [], "model_id": "stub"}),
+            _stub_response(inference_payload),
+        ]
+
+        provider = EncoderfileProvider(base_url="http://my-server:8080/")
+        provider.load_model("ProtectAI/deberta-v3-base-prompt-injection-v2")
+        result = provider.infer(GuardrailPreprocessOutput(data={"inputs": ["test"]}))
+
+        assert provider.base_url == "http://my-server:8080"
+        infer_call = mock_urlopen.call_args_list[-1]
+        assert infer_call.args[0].full_url == "http://my-server:8080/predict"
+        assert isinstance(result, GuardrailInferenceOutput)
+        assert result.data["predicted_labels"] == ["INJECTION"]
+        # Logits are returned as a numpy array (same uniform shape as the spawn path).
+        assert isinstance(result.data["logits"], np.ndarray)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_in_message"),
+    [
+        ({"binary_path": "/tmp/x.encoderfile"}, "binary_path"),  # noqa: S108 - path is never touched; constructor rejects before any I/O
+        ({"port": 8000}, "port"),
+        ({"encoderfile_repo": "someone-else/encoderfile-fork"}, "encoderfile_repo"),
+    ],
+)
+def test_external_mode_rejects_mutually_exclusive_kwargs(kwargs: dict[str, Any], expected_in_message: str) -> None:
+    """Constructor-time validation: spawn-only knobs can't be combined with base_url."""
+    with pytest.raises(ValueError, match=expected_in_message):
+        EncoderfileProvider(base_url="http://localhost:9999", **kwargs)
+
+
+def test_external_mode_default_encoderfile_repo_is_not_a_conflict() -> None:
+    """The default value of ``encoderfile_repo`` is not flagged — only an active override is."""
+    # Should not raise.
+    provider = EncoderfileProvider(base_url="http://localhost:9999")
+    assert provider.base_url == "http://localhost:9999"
+
+
+def test_external_mode_rejects_invalid_url_scheme() -> None:
+    """``base_url`` must include an http(s) scheme to avoid surprising urlopen behavior."""
+    with pytest.raises(ValueError, match="http://"):
+        EncoderfileProvider(base_url="localhost:9999")
+
+
+def test_external_mode_close_is_noop_and_preserves_base_url() -> None:
+    """``close()`` must not blank ``base_url`` in external mode — the provider should stay reusable."""
+    with patch("any_guardrail.providers.encoderfile.urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value = _stub_response({"results": [], "model_id": "stub"})
+
+        provider = EncoderfileProvider(base_url="http://localhost:9999")
+        provider.load_model("ProtectAI/deberta-v3-base-prompt-injection-v2")
+        provider.close()
+
+        assert provider.base_url == "http://localhost:9999"
+        assert provider.process is None

--- a/tests/unit/test_unit_llamafile_provider.py
+++ b/tests/unit/test_unit_llamafile_provider.py
@@ -552,3 +552,88 @@ def test_load_model_gives_up_after_max_bind_race_retries(tmp_path: Any) -> None:
             provider.load_model("ibm-granite/granite-guardian-4.1-8b")
 
     assert mock_popen.call_count == LlamafileProvider._BIND_RACE_RETRIES
+
+
+# ----- external-server mode -----
+
+
+def test_external_mode_skips_subprocess() -> None:
+    """``base_url=`` short-circuits download + spawn; only readiness probe runs."""
+    with (
+        patch("any_guardrail.providers.llamafile.subprocess.Popen") as mock_popen,
+        patch("any_guardrail.providers.llamafile.urllib.request.urlopen") as mock_urlopen,
+    ):
+        mock_urlopen.return_value = _stub_response({"status": "ok"})
+
+        provider = LlamafileProvider(base_url="http://localhost:9999")
+        provider.load_model("ibm-granite/granite-guardian-4.1-8b")
+
+        mock_popen.assert_not_called()
+        # Readiness was probed against the supplied URL.
+        probed_urls = [call.args[0].full_url for call in mock_urlopen.call_args_list]
+        assert "http://localhost:9999/health" in probed_urls
+        assert provider.base_url == "http://localhost:9999"
+        assert provider.process is None
+        assert provider.model_id == "ibm-granite/granite-guardian-4.1-8b"
+
+
+def test_external_mode_generate_chat_targets_supplied_url() -> None:
+    """``generate_chat`` POSTs to the user-supplied URL's chat-completions endpoint."""
+    with patch("any_guardrail.providers.llamafile.urllib.request.urlopen") as mock_urlopen:
+        # First call: readiness probe; subsequent: chat completion.
+        mock_urlopen.side_effect = [
+            _stub_response({"status": "ok"}),
+            _stub_response(
+                {
+                    "choices": [{"message": {"content": "hi"}}],
+                    "usage": {"prompt_tokens": 4, "completion_tokens": 1},
+                }
+            ),
+        ]
+
+        provider = LlamafileProvider(base_url="http://my-server:8080/")
+        provider.load_model("ibm-granite/granite-guardian-4.1-8b")
+        result = provider.generate_chat([{"role": "user", "content": "hi"}], max_new_tokens=5)
+
+        # Trailing slash on base_url was stripped at __init__.
+        assert provider.base_url == "http://my-server:8080"
+        # The chat call hit the right URL on the external host.
+        chat_call = mock_urlopen.call_args_list[-1]
+        assert chat_call.args[0].full_url == "http://my-server:8080/v1/chat/completions"
+        assert result.data["generated_text"] == "hi"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_in_message"),
+    [
+        ({"binary_path": "/tmp/x.llamafile"}, "binary_path"),  # noqa: S108 - path is never touched; constructor rejects before any I/O
+        ({"port": 8000}, "port"),
+        ({"n_gpu_layers": 8}, "n_gpu_layers"),
+        ({"context_size": 2048}, "context_size"),
+        ({"extra_args": ["--verbose"]}, "extra_args"),
+        ({"repo_id": "foo/bar", "filename": "x.llamafile"}, "repo_id"),
+    ],
+)
+def test_external_mode_rejects_mutually_exclusive_kwargs(kwargs: dict[str, Any], expected_in_message: str) -> None:
+    """Constructor-time validation: spawn-only knobs can't be combined with base_url."""
+    with pytest.raises(ValueError, match=expected_in_message):
+        LlamafileProvider(base_url="http://localhost:9999", **kwargs)
+
+
+def test_external_mode_rejects_invalid_url_scheme() -> None:
+    """``base_url`` must include an http(s) scheme to avoid surprising urlopen behavior."""
+    with pytest.raises(ValueError, match="http://"):
+        LlamafileProvider(base_url="localhost:9999")
+
+
+def test_external_mode_close_is_noop_and_preserves_base_url() -> None:
+    """``close()`` must not blank ``base_url`` in external mode — the provider should stay reusable."""
+    with patch("any_guardrail.providers.llamafile.urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value = _stub_response({"status": "ok"})
+
+        provider = LlamafileProvider(base_url="http://localhost:9999")
+        provider.load_model("ibm-granite/granite-guardian-4.1-8b")
+        provider.close()
+
+        assert provider.base_url == "http://localhost:9999"
+        assert provider.process is None


### PR DESCRIPTION
## Summary

Adds a `base_url` constructor parameter to `LlamafileProvider` and `EncoderfileProvider` so users can point at a server they spun up themselves instead of having any-guardrail download + spawn a binary.

```python
# Bring-your-own-server mode — no download, no subprocess.
provider = LlamafileProvider(base_url="http://localhost:9999")
guardrail = GraniteGuardian(criteria=..., provider=provider)
guardrail.validate("hello")
```

- `load_model()` skips binary resolution and subprocess spawning; it only polls the supplied URL for readiness.
- `close()` is a no-op in external mode and preserves `self.base_url` so the provider stays reusable.
- Spawn-only knobs are mutually exclusive with `base_url` and raise `ValueError` at construction:
  - **Llamafile**: `binary_path`, `repo_id`/`filename`, `port`, `n_gpu_layers`, `context_size`, `extra_args`.
  - **Encoderfile**: `binary_path`, `port`, non-default `encoderfile_repo`.
- `base_url` must start with `http://` or `https://`; trailing `/` is stripped.

## Test plan

- [x] `pytest tests/unit` — 151 passed (8 new tests for external mode across both providers: subprocess-skipping, URL targeting, conflict rejection, scheme validation, close-is-noop).
- [x] `pre-commit run --all-files` — ruff, mypy strict, codespell, nbstripout all pass.
- [ ] Manual smoke (not run here, requires a real binary): start `./Llama-3.2-1B-Instruct.Q6_K.llamafile --port 9999 --no-webui`, then construct `LlamafileProvider(base_url="http://localhost:9999")` and call `generate_chat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)