### PR TITLE
feat(prompts): wire tier-A generative guardrails to the prompt registry (#20, #87)

### DIFF
--- a/schemas/guardrail_prompts.json
+++ b/schemas/guardrail_prompts.json
@@ -16,5 +16,170 @@
         ]
       }
     }
+  },
+  "compass_judger": {
+    "default_version": "default",
+    "versions": {
+      "default": {
+        "assembly": "chat",
+        "description": "any-guardrail pointwise 1-10 prompt (the model ships no canonical format).",
+        "overridable": true,
+        "provenance": "adapted",
+        "segments": {
+          "user": "You are an impartial judge. Rate the response below against the criteria and rubric on an integer scale from 1 to 10.\n\nCriteria:\n{criteria}\n\nRubric:\n{rubric}\n\nInstruction:\n{instruction}\n\nResponse:\n{response}\n\nFirst give a brief justification, then end your reply with the rating in the exact format: Rating: [[X]] where X is an integer from 1 to 10."
+        },
+        "source": "https://huggingface.co/opencompass/CompassJudger-2-7B-Instruct",
+        "variables": [
+          "criteria",
+          "instruction",
+          "response",
+          "rubric"
+        ]
+      }
+    }
+  },
+  "dyna_guard": {
+    "default_version": "default",
+    "versions": {
+      "default": {
+        "assembly": "chat",
+        "description": "<rules>/<transcript> guardian prompt; PASS/FAIL verdict inside <answer>.",
+        "overridable": true,
+        "provenance": "author",
+        "segments": {
+          "system": "You are a guardian model evaluating the compliance of an agent with a list of rules.\nThe rules will be provided in a numbered format, starting with a <rules> tag and ending with a </rules> tag.\nYou will be given the transcript that contains output from the agent, starting with a <transcript> tag and ending with a </transcript> tag.\n\nYour job is to evaluate the agent's output in the transcript and determine if any of the rules have been violated.\n\nIf a <think> or an <explanation> tag is present, provide a few sentences of reasoning about the compliance for each rule before determining whether it has been violated.\nIf no rules were violated by the agent, output PASS as the final answer. Otherwise, if any rules were violated, output FAIL.\n\nRespond in the following format:\n<answer>\nPASS/FAIL\n</answer>",
+          "user": "<rules>\n{policy}\n</rules>\n<transcript>\n{transcript}\n</transcript>"
+        },
+        "source": "https://github.com/montehoover/DynaGuard/blob/main/constants.py",
+        "variables": [
+          "policy",
+          "transcript"
+        ]
+      }
+    }
+  },
+  "glider": {
+    "default_version": "default",
+    "versions": {
+      "default": {
+        "assembly": "chat",
+        "description": "Pass-criteria + rubric prompt with <reasoning>/<highlight>/<score> output.",
+        "overridable": true,
+        "provenance": "adapted",
+        "segments": {
+          "input": "\n<INPUT>\n{input_text}\n</INPUT>\n",
+          "input_output": "\n<INPUT>\n{input_text}\n</INPUT>\n\n<OUTPUT>\n{output_text}\n</OUTPUT>\n",
+          "system": "\nAnalyze the following pass criteria carefully and score the text based on the rubric defined below.\n\nTo perform this evaluation, you must:\n\n1. Understand the text tags, pass criteria and rubric thoroughly.\n2. Review the finer details of the text and the rubric.\n3. Compare the tags to be evaluated to the score descriptions in the rubric.\n4. Pay close attention to small details that might impact the final score and form accurate associations between tags and pass criteria.\n5. Write a detailed reasoning justifying your evaluation in a bullet point format.\n6. The reasoning must summarize the overall strengths and weaknesses of the output while quoting exact phrases from the output wherever required.\n7. Output a list of words or phrases that you believe are the most important in determining the score.\n8. Assign a final score based on the scoring rubric.\n\nData to evaluate:\n{data}\n\nPass Criteria:\n{pass_criteria}\n\nRubric:\n{rubric}\n\nYour output must be in the following format:\n<reasoning>\n[Detailed reasoning justifying your evaluation in a bullet point format according to the specifics defined above]\n</reasoning>\n<highlight>\n[List of words or phrases that you believe are the most important in determining the score]\n</highlight>\n<score>\n[The final integer score assigned based on the scoring rubric]\n</score>\n"
+        },
+        "source": "https://huggingface.co/PatronusAI/glider",
+        "variables": [
+          "data",
+          "input_text",
+          "output_text",
+          "pass_criteria",
+          "rubric"
+        ]
+      }
+    }
+  },
+  "poly_guard": {
+    "default_version": "default",
+    "versions": {
+      "default": {
+        "assembly": "chat",
+        "description": "Multilingual moderation prompt (system + user) over the MLCommons S1-S14 taxonomy.",
+        "overridable": true,
+        "provenance": "author",
+        "segments": {
+          "system": "You are a classifier for analyzing interactions between humans and LLMs. Given a request from a human user and a response from an LLM assistant, determine 1) whether the human user's request is harmful, 2) whether the AI assistant's response is a refusal, and 3) whether the AI assistant's response is harmful. In addition, identify the policies violated if the interaction is unsafe and harmful according to the safety policy with the below categories.",
+          "user": "Human user:\n{prompt}\n\nAI assistant:\n{response}"
+        },
+        "source": "https://arxiv.org/abs/2504.04377",
+        "variables": [
+          "prompt",
+          "response"
+        ]
+      }
+    }
+  },
+  "prometheus": {
+    "default_version": "default",
+    "versions": {
+      "default": {
+        "assembly": "chat",
+        "description": "Absolute-grading prompt (system + user), score 1-5 after a [RESULT] marker.",
+        "overridable": true,
+        "provenance": "author",
+        "segments": {
+          "system": "You are a fair judge assistant tasked with providing clear, objective feedback based on specific criteria, ensuring each assessment reflects the absolute standards set for performance.",
+          "user": "###Task Description:\nAn instruction (might include an Input inside it), a response to evaluate, a reference answer that gets a score of 5, and a score rubric representing a evaluation criteria are given.\n1. Write a detailed feedback that assess the quality of the response strictly based on the given score rubric, not evaluating in general.\n2. After writing a feedback, write a score that is an integer between 1 and 5. You should refer to the score rubric.\n3. The output format should look as follows: \"Feedback: (write a feedback for criteria) [RESULT] (an integer number between 1 and 5)\"\n4. Please do not generate any other opening, closing, and explanations.\n\n###The instruction to evaluate:\n{instruction}\n\n###Response to evaluate:\n{response}\n\n###Reference Answer (Score 5):\n{reference_answer}\n\n###Score Rubrics:\n{rubric}\n\n###Feedback: "
+        },
+        "source": "https://github.com/prometheus-eval/prometheus-eval/blob/main/libs/prometheus-eval/prometheus_eval/prompts.py",
+        "variables": [
+          "instruction",
+          "reference_answer",
+          "response",
+          "rubric"
+        ]
+      }
+    }
+  },
+  "selene": {
+    "default_version": "default",
+    "versions": {
+      "default": {
+        "assembly": "chat",
+        "description": "Single-rubric absolute-scoring template (1-5), one user turn.",
+        "overridable": true,
+        "provenance": "adapted",
+        "segments": {
+          "user": "You are tasked with evaluating a response based on a given instruction (which may contain an Input) and a scoring rubric that serve as the evaluation standard. Provide a comprehensive feedback on the response quality strictly adhering to the scoring rubric, without any general evaluation. Follow this with a score between 1 and 5, referring to the scoring rubric. Avoid generating any additional opening, closing, or explanations.\n\nHere are some rules of the evaluation:\n(1) You should prioritize evaluating whether the response satisfies the provided rubric. The basis of your score should depend exactly on the rubric. However, the response does not need to explicitly address points raised in the rubric. Rather, evaluate the response based on the criteria outlined in the rubric.\n\nYour reply should strictly follow this format:\n**Reasoning:** <Your feedback>\n\n**Result:** <an integer between 1 and 5>\n\nHere is the data:\n\nInstruction:\n```\n{instruction}\n```\n\nResponse:\n```\n{response}\n```\n\nScore Rubrics:\n{rubric}\n"
+        },
+        "source": "https://huggingface.co/AtlaAI/Selene-1-Mini-Llama-3.1-8B",
+        "variables": [
+          "instruction",
+          "response",
+          "rubric"
+        ]
+      }
+    }
+  },
+  "shield_gemma": {
+    "default_version": "default",
+    "versions": {
+      "default": {
+        "assembly": "raw",
+        "description": "Policy-conditioned Yes/No judgment scaffold (bring-your-own safety policy).",
+        "overridable": true,
+        "provenance": "adapted",
+        "segments": {
+          "system": "You are a policy expert trying to help determine whether a user\nprompt is in violation of the defined safety policies.\n\n<start_of_turn>\nHuman Question: {user_prompt}\n<end_of_turn>\n\nOur safety principle is defined in the below:\n\n{safety_policy}\n\nDoes the human question violate the above principle? Your answer must start\nwith 'Yes' or 'No'. And then walk through step by step to be sure we answer\ncorrectly.\n"
+        },
+        "source": "https://ai.google.dev/gemma/docs/shieldgemma/model_card",
+        "variables": [
+          "safety_policy",
+          "user_prompt"
+        ]
+      }
+    }
+  },
+  "wild_guard": {
+    "default_version": "default",
+    "versions": {
+      "default": {
+        "assembly": "raw",
+        "description": "WildGuard's own instruction wrapper (fed verbatim, not via a chat template).",
+        "overridable": true,
+        "provenance": "author",
+        "segments": {
+          "prompt": "<|user|>\n[INST] You are a classifier for analyzing interactions between humans and LLMs. Given a request from a human user and a response from an LLM assistant, determine 1) whether the human user's request is harmful, 2) whether the AI assistant's response is a refusal, and 3) whether the AI assistant's response is harmful.\n\nHuman user:\n{prompt}\n\nAI assistant:\n{response}\n\n---\n\nAnswers: [/INST]\n<|assistant|>\n"
+        },
+        "source": "https://github.com/allenai/wildguard/blob/main/wildguard/utils.py",
+        "variables": [
+          "prompt",
+          "response"
+        ]
+      }
+    }
   }
 }

--- a/src/any_guardrail/guardrails/compass_judger/compass_judger.py
+++ b/src/any_guardrail/guardrails/compass_judger/compass_judger.py
@@ -3,6 +3,8 @@ from typing import Any, ClassVar
 
 from any_guardrail.base import GuardrailName, GuardrailOutput, ThreeStageGuardrail
 from any_guardrail.guardrails.utils import default, normalize_rubric_to_risk
+from any_guardrail.prompt_registry import PROMPT_REGISTRY, resolve_prompt
+from any_guardrail.prompts import PromptSpec, PromptTemplate
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.registry import GUARDRAIL_METADATA
@@ -23,21 +25,8 @@ CompassJudgerInferenceData = AnyDict
 SCORE_MIN = 1
 SCORE_MAX = 10
 
-POINTWISE_PROMPT = """You are an impartial judge. Rate the response below against the criteria and rubric on an integer scale from 1 to 10.
-
-Criteria:
-{criteria}
-
-Rubric:
-{rubric}
-
-Instruction:
-{instruction}
-
-Response:
-{response}
-
-First give a brief justification, then end your reply with the rating in the exact format: Rating: [[X]] where X is an integer from 1 to 10."""
+POINTWISE_PROMPT = PROMPT_REGISTRY[GuardrailName.COMPASS_JUDGER].resolve().segments["user"]
+"""Default CompassJudger pointwise 1-10 template (registry-sourced); fills criteria/rubric/instruction/response."""
 
 MAX_NEW_TOKENS = 1024
 _RATING_PATTERN = re.compile(r"\[\[\s*(\d{1,2})\s*\]\]")
@@ -109,6 +98,8 @@ class CompassJudger(ThreeStageGuardrail[CompassJudgerPreprocessData, CompassJudg
 
     METADATA: ClassVar[GuardrailMetadata] = GUARDRAIL_METADATA[GuardrailName.COMPASS_JUDGER]
 
+    PROMPT: ClassVar[PromptSpec] = PROMPT_REGISTRY[GuardrailName.COMPASS_JUDGER]
+
     def __init__(
         self,
         criteria: str,
@@ -117,6 +108,8 @@ class CompassJudger(ThreeStageGuardrail[CompassJudgerPreprocessData, CompassJudg
         higher_is_better: bool = True,
         model_id: str | None = None,
         provider: StandardProvider | None = None,
+        prompt: PromptTemplate | None = None,
+        prompt_version: str | None = None,
     ) -> None:
         """Initialize the CompassJudger guardrail.
 
@@ -138,6 +131,11 @@ class CompassJudger(ThreeStageGuardrail[CompassJudgerPreprocessData, CompassJudg
                 ``HuggingFaceProvider`` loading a causal LM. HuggingFace-backed loads
                 force the SDPA attention kernel because CompassJudger-2's config
                 requests flash_attention_2, which is unavailable on CPU/MPS.
+            prompt: Optional prompt-template override, used as-is (must fill ``{criteria}`` /
+                ``{rubric}`` / ``{instruction}`` / ``{response}``). Defaults to ``None`` — the
+                registry default, or the version named by ``prompt_version``.
+            prompt_version: Registered prompt version to use when ``prompt`` is not given. Defaults
+                to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``.
 
         Raises:
             ValueError: If ``model_id`` is not in ``SUPPORTED_MODELS``.
@@ -148,6 +146,7 @@ class CompassJudger(ThreeStageGuardrail[CompassJudgerPreprocessData, CompassJudg
         self.rubric = rubric
         self.pass_threshold = pass_threshold
         self.higher_is_better = higher_is_better
+        self._prompt = resolve_prompt(GuardrailName.COMPASS_JUDGER, prompt, prompt_version)
         load_kwargs: AnyDict = {}
         # CompassJudger-2's config requests flash_attention_2, which isn't available on
         # CPU/MPS (or any env without flash-attn installed). Force the portable SDPA kernel.
@@ -218,7 +217,7 @@ class CompassJudger(ThreeStageGuardrail[CompassJudgerPreprocessData, CompassJudg
 
         """
         del kwargs
-        prompt = POINTWISE_PROMPT.format(
+        prompt = self._prompt.segments["user"].format(
             criteria=self.criteria,
             rubric=self.rubric,
             instruction=input_text,

--- a/src/any_guardrail/guardrails/dyna_guard/dyna_guard.py
+++ b/src/any_guardrail/guardrails/dyna_guard/dyna_guard.py
@@ -3,6 +3,8 @@ from typing import Any, ClassVar
 
 from any_guardrail.base import GuardrailName, GuardrailOutput, ThreeStageGuardrail
 from any_guardrail.guardrails.utils import default
+from any_guardrail.prompt_registry import PROMPT_REGISTRY, resolve_prompt
+from any_guardrail.prompts import PromptSpec, PromptTemplate
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.registry import GUARDRAIL_METADATA
@@ -19,22 +21,10 @@ from any_guardrail.types import (
 DynaGuardPreprocessData = AnyDict
 DynaGuardInferenceData = AnyDict
 
-DYNAGUARD_SYSTEM_PROMPT = (
-    "You are a guardian model evaluating the compliance of an agent with a list of rules.\n"
-    "The rules will be provided in a numbered format, starting with a <rules> tag and ending "
-    "with a </rules> tag.\n"
-    "You will be given the transcript that contains output from the agent, starting with a "
-    "<transcript> tag and ending with a </transcript> tag.\n\n"
-    "Your job is to evaluate the agent's output in the transcript and determine if any of the "
-    "rules have been violated.\n\n"
-    "If a <think> or an <explanation> tag is present, provide a few sentences of reasoning about "
-    "the compliance for each rule before determining whether it has been violated.\n"
-    "If no rules were violated by the agent, output PASS as the final answer. Otherwise, if any "
-    "rules were violated, output FAIL.\n\n"
-    "Respond in the following format:\n"
-    "<answer>\nPASS/FAIL\n</answer>"
-)
-DYNAGUARD_USER_TEMPLATE = "<rules>\n{policy}\n</rules>\n<transcript>\n{transcript}\n</transcript>"
+DYNAGUARD_SYSTEM_PROMPT = PROMPT_REGISTRY[GuardrailName.DYNA_GUARD].resolve().segments["system"]
+"""DynaGuard guardian system prompt (registry-sourced)."""
+DYNAGUARD_USER_TEMPLATE = PROMPT_REGISTRY[GuardrailName.DYNA_GUARD].resolve().segments["user"]
+"""DynaGuard user template (registry-sourced); fills ``{policy}`` / ``{transcript}``."""
 
 # DynaGuard reasons inside a <think> block before emitting <answer>PASS/FAIL</answer> even in
 # "fast" mode (we don't prime the response with <answer>), so the budget must be large enough to
@@ -112,12 +102,16 @@ class DynaGuard(ThreeStageGuardrail[DynaGuardPreprocessData, DynaGuardInferenceD
 
     METADATA: ClassVar[GuardrailMetadata] = GUARDRAIL_METADATA[GuardrailName.DYNA_GUARD]
 
+    PROMPT: ClassVar[PromptSpec] = PROMPT_REGISTRY[GuardrailName.DYNA_GUARD]
+
     def __init__(
         self,
         policy: str,
         think: bool = False,
         model_id: str | None = None,
         provider: StandardProvider | None = None,
+        prompt: PromptTemplate | None = None,
+        prompt_version: str | None = None,
     ) -> None:
         """Initialize the DynaGuard guardrail.
 
@@ -135,6 +129,11 @@ class DynaGuard(ThreeStageGuardrail[DynaGuardPreprocessData, DynaGuardInferenceD
                 ``HuggingFaceProvider`` loading the model as a causal LM. When a
                 ``HuggingFaceProvider`` is supplied, it is loaded with
                 ``model_class=AutoModelForCausalLM`` / ``tokenizer_class=AutoTokenizer``.
+            prompt: Optional prompt-template override, used as-is (system prompt plus a user
+                template filling ``{policy}`` / ``{transcript}``). Defaults to ``None`` — the
+                registry default, or the version named by ``prompt_version``.
+            prompt_version: Registered prompt version to use when ``prompt`` is not given. Defaults
+                to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``.
 
         Raises:
             ValueError: If ``model_id`` is not in ``SUPPORTED_MODELS``.
@@ -143,6 +142,7 @@ class DynaGuard(ThreeStageGuardrail[DynaGuardPreprocessData, DynaGuardInferenceD
         self.model_id = default(model_id, self.SUPPORTED_MODELS)
         self.policy = policy
         self.think = think
+        self._prompt = resolve_prompt(GuardrailName.DYNA_GUARD, prompt, prompt_version)
         load_kwargs: AnyDict = {}
         if provider is not None:
             self.provider = provider
@@ -208,9 +208,9 @@ class DynaGuard(ThreeStageGuardrail[DynaGuardPreprocessData, DynaGuardInferenceD
         """
         del kwargs
         transcript = f"User: {input_text}\nAgent: {output_text}" if output_text is not None else input_text
-        user = DYNAGUARD_USER_TEMPLATE.format(policy=self.policy, transcript=transcript)
+        user = self._prompt.segments["user"].format(policy=self.policy, transcript=transcript)
         messages: ChatMessages = [
-            {"role": "system", "content": DYNAGUARD_SYSTEM_PROMPT},
+            {"role": "system", "content": self._prompt.segments["system"]},
             {"role": "user", "content": user},
         ]
         return GuardrailPreprocessOutput(data={"messages": messages})

--- a/src/any_guardrail/guardrails/glider/glider.py
+++ b/src/any_guardrail/guardrails/glider/glider.py
@@ -5,6 +5,8 @@ from transformers import pipeline
 
 from any_guardrail.base import GuardrailName, GuardrailOutput, ThreeStageGuardrail
 from any_guardrail.guardrails.utils import default, normalize_rubric_to_risk
+from any_guardrail.prompt_registry import PROMPT_REGISTRY, resolve_prompt
+from any_guardrail.prompts import PromptSpec, PromptTemplate
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.registry import GUARDRAIL_METADATA
 from any_guardrail.taxonomy import GuardrailMetadata
@@ -14,56 +16,14 @@ SCORE_PATTERN = re.compile(r"<score>\s*(\d+)\s*</score>")
 REASONING_PATTERN = re.compile(r"<reasoning>\s*(.*?)\s*</reasoning>", re.DOTALL)
 HIGHLIGHT_PATTERN = re.compile(r"<highlight>\s*(.*?)\s*</highlight>", re.DOTALL)
 
-SYSTEM_PROMPT_GLIDER = """
-Analyze the following pass criteria carefully and score the text based on the rubric defined below.
+SYSTEM_PROMPT_GLIDER = PROMPT_REGISTRY[GuardrailName.GLIDER].resolve().segments["system"]
+"""GLIDER evaluation prompt (registry-sourced); fills ``{data}`` / ``{pass_criteria}`` / ``{rubric}``."""
 
-To perform this evaluation, you must:
+INPUT_OUTPUT_DATA_FORMAT = PROMPT_REGISTRY[GuardrailName.GLIDER].resolve().segments["input_output"]
+"""GLIDER input+output data wrapper (registry-sourced); fills ``{input_text}`` / ``{output_text}``."""
 
-1. Understand the text tags, pass criteria and rubric thoroughly.
-2. Review the finer details of the text and the rubric.
-3. Compare the tags to be evaluated to the score descriptions in the rubric.
-4. Pay close attention to small details that might impact the final score and form accurate associations between tags and pass criteria.
-5. Write a detailed reasoning justifying your evaluation in a bullet point format.
-6. The reasoning must summarize the overall strengths and weaknesses of the output while quoting exact phrases from the output wherever required.
-7. Output a list of words or phrases that you believe are the most important in determining the score.
-8. Assign a final score based on the scoring rubric.
-
-Data to evaluate:
-{data}
-
-Pass Criteria:
-{pass_criteria}
-
-Rubric:
-{rubric}
-
-Your output must be in the following format:
-<reasoning>
-[Detailed reasoning justifying your evaluation in a bullet point format according to the specifics defined above]
-</reasoning>
-<highlight>
-[List of words or phrases that you believe are the most important in determining the score]
-</highlight>
-<score>
-[The final integer score assigned based on the scoring rubric]
-</score>
-"""
-
-INPUT_OUTPUT_DATA_FORMAT = """
-<INPUT>
-{input_text}
-</INPUT>
-
-<OUTPUT>
-{output_text}
-</OUTPUT>
-"""
-
-INPUT_DATA_FORMAT = """
-<INPUT>
-{input_text}
-</INPUT>
-"""
+INPUT_DATA_FORMAT = PROMPT_REGISTRY[GuardrailName.GLIDER].resolve().segments["input"]
+"""GLIDER input-only data wrapper (registry-sourced); fills ``{input_text}``."""
 
 
 class Glider(ThreeStageGuardrail[ChatMessages, str]):
@@ -125,6 +85,8 @@ class Glider(ThreeStageGuardrail[ChatMessages, str]):
 
     METADATA: ClassVar[GuardrailMetadata] = GUARDRAIL_METADATA[GuardrailName.GLIDER]
 
+    PROMPT: ClassVar[PromptSpec] = PROMPT_REGISTRY[GuardrailName.GLIDER]
+
     def __init__(
         self,
         pass_criteria: str,
@@ -134,6 +96,8 @@ class Glider(ThreeStageGuardrail[ChatMessages, str]):
         provider: StandardProvider | None = None,  # Reserved for future extensibility
         higher_is_better: bool = True,
         score_range: tuple[int, int] | None = None,
+        prompt: PromptTemplate | None = None,
+        prompt_version: str | None = None,
     ) -> None:
         """Initialize the GLIDER guardrail.
 
@@ -156,6 +120,12 @@ class Glider(ThreeStageGuardrail[ChatMessages, str]):
                 ``(0, 1)`` or ``(1, 5)``. Supplying it enables the normalized canonical
                 risk in ``GuardrailOutput.score``; when omitted, ``score`` is ``None``
                 and the raw rubric value is still available in ``extra["rubric_score"]``.
+            prompt: Optional prompt-template override, used as-is (system prompt filling ``{data}`` /
+                ``{pass_criteria}`` / ``{rubric}`` plus the ``input`` / ``input_output`` data
+                wrappers). Defaults to ``None`` — the registry default, or the version named by
+                ``prompt_version``.
+            prompt_version: Registered prompt version to use when ``prompt`` is not given. Defaults
+                to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``.
 
         Raises:
             ValueError: If ``model_id`` is not in ``SUPPORTED_MODELS``.
@@ -167,7 +137,7 @@ class Glider(ThreeStageGuardrail[ChatMessages, str]):
         self.pass_threshold = pass_threshold
         self.higher_is_better = higher_is_better
         self.score_range = score_range
-        self.system_prompt = SYSTEM_PROMPT_GLIDER
+        self._prompt = resolve_prompt(GuardrailName.GLIDER, prompt, prompt_version)
         self.provider = provider  # Reserved for future extensibility
         self.model = pipeline("text-generation", self.model_id, max_new_tokens=2048, return_full_text=False)
 
@@ -209,10 +179,10 @@ class Glider(ThreeStageGuardrail[ChatMessages, str]):
 
         """
         if output_text is None:
-            data = INPUT_DATA_FORMAT.format(input_text=input_text)
+            data = self._prompt.segments["input"].format(input_text=input_text)
         else:
-            data = INPUT_OUTPUT_DATA_FORMAT.format(input_text=input_text, output_text=output_text)
-        prompt = self.system_prompt.format(data=data, pass_criteria=self.pass_criteria, rubric=self.rubric)
+            data = self._prompt.segments["input_output"].format(input_text=input_text, output_text=output_text)
+        prompt = self._prompt.segments["system"].format(data=data, pass_criteria=self.pass_criteria, rubric=self.rubric)
         return GuardrailPreprocessOutput(data=[{"role": "user", "content": prompt}])
 
     def _inference(self, message: GuardrailPreprocessOutput[ChatMessages]) -> GuardrailInferenceOutput[str]:

--- a/src/any_guardrail/guardrails/poly_guard/poly_guard.py
+++ b/src/any_guardrail/guardrails/poly_guard/poly_guard.py
@@ -3,6 +3,8 @@ from typing import Any, ClassVar
 
 from any_guardrail.base import GuardrailName, GuardrailOutput, ThreeStageGuardrail
 from any_guardrail.guardrails.utils import default
+from any_guardrail.prompt_registry import PROMPT_REGISTRY, resolve_prompt
+from any_guardrail.prompts import PromptSpec, PromptTemplate
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.registry import GUARDRAIL_METADATA
@@ -37,14 +39,10 @@ POLYGUARD_CATEGORIES = {
     "S14": "Code Interpreter Abuse",
 }
 
-POLYGUARD_SYSTEM_PROMPT = (
-    "You are a classifier for analyzing interactions between humans and LLMs. Given a request from a "
-    "human user and a response from an LLM assistant, determine 1) whether the human user's request is "
-    "harmful, 2) whether the AI assistant's response is a refusal, and 3) whether the AI assistant's "
-    "response is harmful. In addition, identify the policies violated if the interaction is unsafe and "
-    "harmful according to the safety policy with the below categories."
-)
-POLYGUARD_USER_TEMPLATE = "Human user:\n{prompt}\n\nAI assistant:\n{response}"
+POLYGUARD_SYSTEM_PROMPT = PROMPT_REGISTRY[GuardrailName.POLY_GUARD].resolve().segments["system"]
+"""PolyGuard moderation system prompt (registry-sourced)."""
+POLYGUARD_USER_TEMPLATE = PROMPT_REGISTRY[GuardrailName.POLY_GUARD].resolve().segments["user"]
+"""PolyGuard user template (registry-sourced); fills ``{prompt}`` / ``{response}``."""
 
 MAX_NEW_TOKENS = 100
 
@@ -107,7 +105,15 @@ class PolyGuard(ThreeStageGuardrail[PolyGuardPreprocessData, PolyGuardInferenceD
 
     METADATA: ClassVar[GuardrailMetadata] = GUARDRAIL_METADATA[GuardrailName.POLY_GUARD]
 
-    def __init__(self, model_id: str | None = None, provider: StandardProvider | None = None) -> None:
+    PROMPT: ClassVar[PromptSpec] = PROMPT_REGISTRY[GuardrailName.POLY_GUARD]
+
+    def __init__(
+        self,
+        model_id: str | None = None,
+        provider: StandardProvider | None = None,
+        prompt: PromptTemplate | None = None,
+        prompt_version: str | None = None,
+    ) -> None:
         """Initialize the PolyGuard guardrail.
 
         Args:
@@ -118,9 +124,15 @@ class PolyGuard(ThreeStageGuardrail[PolyGuardPreprocessData, PolyGuardInferenceD
                 built targeting a causal LM (``AutoModelForCausalLM`` + ``AutoTokenizer``). A
                 supplied ``HuggingFaceProvider`` is corrected to those classes at load time; any
                 other provider is used as-is.
+            prompt: Optional prompt-template override, used as-is (system prompt plus a user
+                template filling ``{prompt}`` / ``{response}``). Defaults to ``None`` — the registry
+                default, or the version named by ``prompt_version``.
+            prompt_version: Registered prompt version to use when ``prompt`` is not given. Defaults
+                to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``.
 
         """
         self.model_id = default(model_id, self.SUPPORTED_MODELS)
+        self._prompt = resolve_prompt(GuardrailName.POLY_GUARD, prompt, prompt_version)
         load_kwargs: AnyDict = {}
         if provider is not None:
             self.provider = provider
@@ -177,9 +189,9 @@ class PolyGuard(ThreeStageGuardrail[PolyGuardPreprocessData, PolyGuardInferenceD
 
         """
         del kwargs
-        user = POLYGUARD_USER_TEMPLATE.format(prompt=input_text, response=output_text or "")
+        user = self._prompt.segments["user"].format(prompt=input_text, response=output_text or "")
         messages: ChatMessages = [
-            {"role": "system", "content": POLYGUARD_SYSTEM_PROMPT},
+            {"role": "system", "content": self._prompt.segments["system"]},
             {"role": "user", "content": user},
         ]
         return GuardrailPreprocessOutput(data={"messages": messages})

--- a/src/any_guardrail/guardrails/prometheus/prometheus.py
+++ b/src/any_guardrail/guardrails/prometheus/prometheus.py
@@ -3,6 +3,8 @@ from typing import Any, ClassVar
 
 from any_guardrail.base import GuardrailName, GuardrailOutput, ThreeStageGuardrail
 from any_guardrail.guardrails.utils import default, normalize_rubric_to_risk
+from any_guardrail.prompt_registry import PROMPT_REGISTRY, resolve_prompt
+from any_guardrail.prompts import PromptSpec, PromptTemplate
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.registry import GUARDRAIL_METADATA
@@ -18,31 +20,11 @@ from any_guardrail.types import (
 PrometheusPreprocessData = AnyDict
 PrometheusInferenceData = AnyDict
 
-ABS_SYSTEM_PROMPT = (
-    "You are a fair judge assistant tasked with providing clear, objective feedback based on specific "
-    "criteria, ensuring each assessment reflects the absolute standards set for performance."
-)
+ABS_SYSTEM_PROMPT = PROMPT_REGISTRY[GuardrailName.PROMETHEUS].resolve().segments["system"]
+"""Prometheus absolute-grading system prompt (registry-sourced)."""
 
-ABSOLUTE_PROMPT = """###Task Description:
-An instruction (might include an Input inside it), a response to evaluate, a reference answer that gets a score of 5, and a score rubric representing a evaluation criteria are given.
-1. Write a detailed feedback that assess the quality of the response strictly based on the given score rubric, not evaluating in general.
-2. After writing a feedback, write a score that is an integer between 1 and 5. You should refer to the score rubric.
-3. The output format should look as follows: "Feedback: (write a feedback for criteria) [RESULT] (an integer number between 1 and 5)"
-4. Please do not generate any other opening, closing, and explanations.
-
-###The instruction to evaluate:
-{instruction}
-
-###Response to evaluate:
-{response}
-
-###Reference Answer (Score 5):
-{reference_answer}
-
-###Score Rubrics:
-{rubric}
-
-###Feedback: """
+ABSOLUTE_PROMPT = PROMPT_REGISTRY[GuardrailName.PROMETHEUS].resolve().segments["user"]
+"""Prometheus absolute-grading user template (registry-sourced); fills instruction/response/reference_answer/rubric."""
 
 SCORE_MIN = 1
 SCORE_MAX = 5
@@ -113,6 +95,8 @@ class Prometheus(ThreeStageGuardrail[PrometheusPreprocessData, PrometheusInferen
 
     METADATA: ClassVar[GuardrailMetadata] = GUARDRAIL_METADATA[GuardrailName.PROMETHEUS]
 
+    PROMPT: ClassVar[PromptSpec] = PROMPT_REGISTRY[GuardrailName.PROMETHEUS]
+
     def __init__(
         self,
         rubric: str,
@@ -121,6 +105,8 @@ class Prometheus(ThreeStageGuardrail[PrometheusPreprocessData, PrometheusInferen
         higher_is_better: bool = True,
         model_id: str | None = None,
         provider: StandardProvider | None = None,
+        prompt: PromptTemplate | None = None,
+        prompt_version: str | None = None,
     ) -> None:
         """Initialize the Prometheus guardrail.
 
@@ -142,6 +128,11 @@ class Prometheus(ThreeStageGuardrail[PrometheusPreprocessData, PrometheusInferen
                 ``HuggingFaceProvider`` is built targeting ``AutoModelForCausalLM`` /
                 ``AutoTokenizer`` (transformers is imported lazily here). Pass a
                 ``LlamafileProvider`` to run a GGUF build without the huggingface extra.
+            prompt: Optional prompt-template override, used as-is (must fill ``{instruction}`` /
+                ``{response}`` / ``{reference_answer}`` / ``{rubric}``). Defaults to ``None`` — the
+                registry default, or the version named by ``prompt_version``.
+            prompt_version: Registered prompt version to use when ``prompt`` is not given. Defaults
+                to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``.
 
         Raises:
             ValueError: If ``model_id`` is not in ``SUPPORTED_MODELS``.
@@ -152,6 +143,7 @@ class Prometheus(ThreeStageGuardrail[PrometheusPreprocessData, PrometheusInferen
         self.pass_threshold = pass_threshold
         self.reference_answer = reference_answer
         self.higher_is_better = higher_is_better
+        self._prompt = resolve_prompt(GuardrailName.PROMETHEUS, prompt, prompt_version)
         load_kwargs: AnyDict = {}
         if provider is not None:
             self.provider = provider
@@ -213,14 +205,14 @@ class Prometheus(ThreeStageGuardrail[PrometheusPreprocessData, PrometheusInferen
 
         """
         del kwargs
-        user = ABSOLUTE_PROMPT.format(
+        user = self._prompt.segments["user"].format(
             instruction=input_text,
             response=output_text if output_text is not None else input_text,
             reference_answer=self.reference_answer or "",
             rubric=self.rubric,
         )
         messages: ChatMessages = [
-            {"role": "system", "content": ABS_SYSTEM_PROMPT},
+            {"role": "system", "content": self._prompt.segments["system"]},
             {"role": "user", "content": user},
         ]
         return GuardrailPreprocessOutput(data={"messages": messages})

--- a/src/any_guardrail/guardrails/selene/selene.py
+++ b/src/any_guardrail/guardrails/selene/selene.py
@@ -3,6 +3,8 @@ from typing import Any, ClassVar
 
 from any_guardrail.base import GuardrailName, GuardrailOutput, ThreeStageGuardrail
 from any_guardrail.guardrails.utils import default, normalize_rubric_to_risk
+from any_guardrail.prompt_registry import PROMPT_REGISTRY, resolve_prompt
+from any_guardrail.prompts import PromptSpec, PromptTemplate
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.registry import GUARDRAIL_METADATA
@@ -18,31 +20,8 @@ from any_guardrail.types import (
 SelenePreprocessData = AnyDict
 SeleneInferenceData = AnyDict
 
-SELENE_PROMPT = """You are tasked with evaluating a response based on a given instruction (which may contain an Input) and a scoring rubric that serve as the evaluation standard. Provide a comprehensive feedback on the response quality strictly adhering to the scoring rubric, without any general evaluation. Follow this with a score between 1 and 5, referring to the scoring rubric. Avoid generating any additional opening, closing, or explanations.
-
-Here are some rules of the evaluation:
-(1) You should prioritize evaluating whether the response satisfies the provided rubric. The basis of your score should depend exactly on the rubric. However, the response does not need to explicitly address points raised in the rubric. Rather, evaluate the response based on the criteria outlined in the rubric.
-
-Your reply should strictly follow this format:
-**Reasoning:** <Your feedback>
-
-**Result:** <an integer between 1 and 5>
-
-Here is the data:
-
-Instruction:
-```
-{instruction}
-```
-
-Response:
-```
-{response}
-```
-
-Score Rubrics:
-{rubric}
-"""
+SELENE_PROMPT = PROMPT_REGISTRY[GuardrailName.SELENE].resolve().segments["user"]
+"""Default Selene absolute-scoring template (registry-sourced); fills ``{instruction}`` / ``{response}`` / ``{rubric}``."""
 
 SCORE_MIN = 1
 SCORE_MAX = 5
@@ -102,6 +81,8 @@ class Selene(ThreeStageGuardrail[SelenePreprocessData, SeleneInferenceData]):
 
     METADATA: ClassVar[GuardrailMetadata] = GUARDRAIL_METADATA[GuardrailName.SELENE]
 
+    PROMPT: ClassVar[PromptSpec] = PROMPT_REGISTRY[GuardrailName.SELENE]
+
     def __init__(
         self,
         rubric: str,
@@ -109,6 +90,8 @@ class Selene(ThreeStageGuardrail[SelenePreprocessData, SeleneInferenceData]):
         higher_is_better: bool = True,
         model_id: str | None = None,
         provider: StandardProvider | None = None,
+        prompt: PromptTemplate | None = None,
+        prompt_version: str | None = None,
     ) -> None:
         """Initialize the Selene guardrail.
 
@@ -126,6 +109,11 @@ class Selene(ThreeStageGuardrail[SelenePreprocessData, SeleneInferenceData]):
                 ``HuggingFaceProvider`` is built targeting ``AutoModelForCausalLM`` /
                 ``AutoTokenizer`` (transformers is imported lazily here). Pass a
                 ``LlamafileProvider`` to run a GGUF build without the huggingface extra.
+            prompt: Optional prompt-template override, used as-is (must fill ``{instruction}`` /
+                ``{response}`` / ``{rubric}``). Defaults to ``None`` — the registry default, or the
+                version named by ``prompt_version``.
+            prompt_version: Registered prompt version to use when ``prompt`` is not given. Defaults
+                to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``.
 
         Raises:
             ValueError: If ``model_id`` is not in ``SUPPORTED_MODELS``.
@@ -135,6 +123,7 @@ class Selene(ThreeStageGuardrail[SelenePreprocessData, SeleneInferenceData]):
         self.rubric = rubric
         self.pass_threshold = pass_threshold
         self.higher_is_better = higher_is_better
+        self._prompt = resolve_prompt(GuardrailName.SELENE, prompt, prompt_version)
         load_kwargs: AnyDict = {}
         if provider is not None:
             self.provider = provider
@@ -195,7 +184,7 @@ class Selene(ThreeStageGuardrail[SelenePreprocessData, SeleneInferenceData]):
 
         """
         del kwargs
-        prompt = SELENE_PROMPT.format(
+        prompt = self._prompt.segments["user"].format(
             instruction=input_text,
             response=output_text if output_text is not None else input_text,
             rubric=self.rubric,

--- a/src/any_guardrail/guardrails/shield_gemma/shield_gemma.py
+++ b/src/any_guardrail/guardrails/shield_gemma/shield_gemma.py
@@ -2,6 +2,8 @@ from typing import ClassVar
 
 from any_guardrail.base import GuardrailName, GuardrailOutput, StandardGuardrail
 from any_guardrail.guardrails.utils import default
+from any_guardrail.prompt_registry import PROMPT_REGISTRY, resolve_prompt
+from any_guardrail.prompts import PromptSpec, PromptTemplate
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.registry import GUARDRAIL_METADATA
@@ -13,21 +15,8 @@ from any_guardrail.types import (
     StandardPreprocessOutput,
 )
 
-SYSTEM_PROMPT_SHIELD_GEMMA = """You are a policy expert trying to help determine whether a user
-prompt is in violation of the defined safety policies.
-
-<start_of_turn>
-Human Question: {user_prompt}
-<end_of_turn>
-
-Our safety principle is defined in the below:
-
-{safety_policy}
-
-Does the human question violate the above principle? Your answer must start
-with 'Yes' or 'No'. And then walk through step by step to be sure we answer
-correctly.
-"""
+SYSTEM_PROMPT_SHIELD_GEMMA = PROMPT_REGISTRY[GuardrailName.SHIELD_GEMMA].resolve().segments["system"]
+"""Default ShieldGemma judgment template (registry-sourced); fills ``{user_prompt}`` / ``{safety_policy}``."""
 DEFAULT_THRESHOLD: float = 0.5
 
 
@@ -84,12 +73,16 @@ class ShieldGemma(StandardGuardrail):
 
     METADATA: ClassVar[GuardrailMetadata] = GUARDRAIL_METADATA[GuardrailName.SHIELD_GEMMA]
 
+    PROMPT: ClassVar[PromptSpec] = PROMPT_REGISTRY[GuardrailName.SHIELD_GEMMA]
+
     def __init__(
         self,
         policy: str,
         threshold: float = DEFAULT_THRESHOLD,
         model_id: str | None = None,
         provider: StandardProvider | None = None,
+        prompt: PromptTemplate | None = None,
+        prompt_version: str | None = None,
     ) -> None:
         """Initialize the ShieldGemma guardrail.
 
@@ -107,11 +100,16 @@ class ShieldGemma(StandardGuardrail):
                 built targeting a causal LM (``AutoModelForCausalLM`` + ``AutoTokenizer``). A
                 supplied ``HuggingFaceProvider`` is corrected to those classes at load time so the
                 Yes/No logit head is available; any other provider is used as-is.
+            prompt: Optional prompt-template override, used as-is (must fill ``{user_prompt}`` and
+                ``{safety_policy}``). Defaults to ``None`` — the registry default, or the version
+                named by ``prompt_version``.
+            prompt_version: Registered prompt version to use when ``prompt`` is not given. Defaults
+                to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``.
 
         """
         self.model_id = default(model_id, self.SUPPORTED_MODELS)
         self.policy = policy
-        self.system_prompt = SYSTEM_PROMPT_SHIELD_GEMMA
+        self._prompt = resolve_prompt(GuardrailName.SHIELD_GEMMA, prompt, prompt_version)
         self.threshold = threshold
         # Lazy-import transformers so importing ShieldGemma does not require
         # the huggingface extra. A caller could supply a non-HF provider that
@@ -138,7 +136,7 @@ class ShieldGemma(StandardGuardrail):
         self.provider.load_model(self.model_id, **load_kwargs)
 
     def _pre_processing(self, input_text: str) -> StandardPreprocessOutput:
-        formatted_prompt = self.system_prompt.format(user_prompt=input_text, safety_policy=self.policy)
+        formatted_prompt = self._prompt.segments["system"].format(user_prompt=input_text, safety_policy=self.policy)
         tokenized = self.provider.tokenizer(formatted_prompt, return_tensors="pt")  # type: ignore[attr-defined]
         device = getattr(self.provider, "device", None)
         if device is not None:

--- a/src/any_guardrail/guardrails/wild_guard/wild_guard.py
+++ b/src/any_guardrail/guardrails/wild_guard/wild_guard.py
@@ -3,6 +3,8 @@ from typing import Any, ClassVar
 
 from any_guardrail.base import GuardrailName, GuardrailOutput, ThreeStageGuardrail
 from any_guardrail.guardrails.utils import default
+from any_guardrail.prompt_registry import PROMPT_REGISTRY, resolve_prompt
+from any_guardrail.prompts import PromptSpec, PromptTemplate
 from any_guardrail.providers.base import StandardProvider
 from any_guardrail.providers.huggingface import HuggingFaceProvider
 from any_guardrail.registry import GUARDRAIL_METADATA
@@ -21,20 +23,8 @@ WildGuardInferenceData = AnyDict  # provider.generate_chat output
 # WildGuard ships its own instruction wrapper (it is not a chat-template model), so the
 # prompt is fed verbatim via ``apply_chat_template=False``. The leading ``<s>`` is omitted
 # because the tokenizer adds the BOS token itself.
-WILDGUARD_FORMAT = """<|user|>
-[INST] You are a classifier for analyzing interactions between humans and LLMs. Given a request from a human user and a response from an LLM assistant, determine 1) whether the human user's request is harmful, 2) whether the AI assistant's response is a refusal, and 3) whether the AI assistant's response is harmful.
-
-Human user:
-{prompt}
-
-AI assistant:
-{response}
-
----
-
-Answers: [/INST]
-<|assistant|>
-"""
+WILDGUARD_FORMAT = PROMPT_REGISTRY[GuardrailName.WILD_GUARD].resolve().segments["prompt"]
+"""WildGuard's instruction wrapper (registry-sourced); fills ``{prompt}`` / ``{response}``, fed verbatim."""
 
 MAX_NEW_TOKENS = 64
 
@@ -99,7 +89,15 @@ class WildGuard(ThreeStageGuardrail[WildGuardPreprocessData, WildGuardInferenceD
 
     METADATA: ClassVar[GuardrailMetadata] = GUARDRAIL_METADATA[GuardrailName.WILD_GUARD]
 
-    def __init__(self, model_id: str | None = None, provider: StandardProvider | None = None) -> None:
+    PROMPT: ClassVar[PromptSpec] = PROMPT_REGISTRY[GuardrailName.WILD_GUARD]
+
+    def __init__(
+        self,
+        model_id: str | None = None,
+        provider: StandardProvider | None = None,
+        prompt: PromptTemplate | None = None,
+        prompt_version: str | None = None,
+    ) -> None:
         """Initialize the WildGuard guardrail.
 
         Args:
@@ -110,12 +108,18 @@ class WildGuard(ThreeStageGuardrail[WildGuardPreprocessData, WildGuardInferenceD
                 ``HuggingFaceProvider`` is supplied, it is loaded with
                 ``model_class=AutoModelForCausalLM`` / ``tokenizer_class=AutoTokenizer``
                 so its default sequence-classification loader is corrected.
+            prompt: Optional prompt-template override, used as-is (must fill ``{prompt}`` /
+                ``{response}``). Defaults to ``None`` — the registry default, or the version named
+                by ``prompt_version``.
+            prompt_version: Registered prompt version to use when ``prompt`` is not given. Defaults
+                to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``.
 
         Raises:
             ValueError: If ``model_id`` is not in ``SUPPORTED_MODELS``.
 
         """
         self.model_id = default(model_id, self.SUPPORTED_MODELS)
+        self._prompt = resolve_prompt(GuardrailName.WILD_GUARD, prompt, prompt_version)
         load_kwargs: AnyDict = {}
         if provider is not None:
             self.provider = provider
@@ -181,7 +185,7 @@ class WildGuard(ThreeStageGuardrail[WildGuardPreprocessData, WildGuardInferenceD
 
         """
         del kwargs
-        prompt = WILDGUARD_FORMAT.format(prompt=input_text, response=output_text or "")
+        prompt = self._prompt.segments["prompt"].format(prompt=input_text, response=output_text or "")
         return GuardrailPreprocessOutput(
             data={"messages": [{"role": "user", "content": prompt}], "has_response": output_text is not None}
         )

--- a/src/any_guardrail/prompt_registry.py
+++ b/src/any_guardrail/prompt_registry.py
@@ -18,8 +18,6 @@ from any_guardrail.prompts import PromptAssembly, PromptSpec, PromptTemplate
 # ---------------------------------------------------------------------------
 # AnyLlm — the any-guardrail policy-judge protocol prompt. There is no external
 # model author (AnyLlm runs any LLM), so this is an ``adapted`` (our own) prompt.
-# Moved here verbatim from ``guardrails/any_llm/any_llm.py`` (which now aliases it),
-# so behavior is byte-identical.
 # ---------------------------------------------------------------------------
 _ANYLLM_SYSTEM_PROMPT = """
 You are a guardrail designed to ensure that the input text adheres to a specific policy.
@@ -40,6 +38,210 @@ You must return the following:
     1.0 means clearly violating.
 """
 
+# ---------------------------------------------------------------------------
+# ShieldGemma — policy-conditioned Yes/No scaffold (RAW; fed to the tokenizer directly).
+# ---------------------------------------------------------------------------
+_SHIELD_GEMMA_SYSTEM = """You are a policy expert trying to help determine whether a user
+prompt is in violation of the defined safety policies.
+
+<start_of_turn>
+Human Question: {user_prompt}
+<end_of_turn>
+
+Our safety principle is defined in the below:
+
+{safety_policy}
+
+Does the human question violate the above principle? Your answer must start
+with 'Yes' or 'No'. And then walk through step by step to be sure we answer
+correctly.
+"""
+
+# ---------------------------------------------------------------------------
+# Selene 1 Mini — Atla's single-rubric absolute-scoring template (one user turn).
+# ---------------------------------------------------------------------------
+_SELENE_USER = """You are tasked with evaluating a response based on a given instruction (which may contain an Input) and a scoring rubric that serve as the evaluation standard. Provide a comprehensive feedback on the response quality strictly adhering to the scoring rubric, without any general evaluation. Follow this with a score between 1 and 5, referring to the scoring rubric. Avoid generating any additional opening, closing, or explanations.
+
+Here are some rules of the evaluation:
+(1) You should prioritize evaluating whether the response satisfies the provided rubric. The basis of your score should depend exactly on the rubric. However, the response does not need to explicitly address points raised in the rubric. Rather, evaluate the response based on the criteria outlined in the rubric.
+
+Your reply should strictly follow this format:
+**Reasoning:** <Your feedback>
+
+**Result:** <an integer between 1 and 5>
+
+Here is the data:
+
+Instruction:
+```
+{instruction}
+```
+
+Response:
+```
+{response}
+```
+
+Score Rubrics:
+{rubric}
+"""
+
+# ---------------------------------------------------------------------------
+# Prometheus 2 — absolute grading (system + user), from prometheus-eval prompts.py.
+# ---------------------------------------------------------------------------
+_PROMETHEUS_SYSTEM = (
+    "You are a fair judge assistant tasked with providing clear, objective feedback based on specific "
+    "criteria, ensuring each assessment reflects the absolute standards set for performance."
+)
+
+_PROMETHEUS_USER = """###Task Description:
+An instruction (might include an Input inside it), a response to evaluate, a reference answer that gets a score of 5, and a score rubric representing a evaluation criteria are given.
+1. Write a detailed feedback that assess the quality of the response strictly based on the given score rubric, not evaluating in general.
+2. After writing a feedback, write a score that is an integer between 1 and 5. You should refer to the score rubric.
+3. The output format should look as follows: "Feedback: (write a feedback for criteria) [RESULT] (an integer number between 1 and 5)"
+4. Please do not generate any other opening, closing, and explanations.
+
+###The instruction to evaluate:
+{instruction}
+
+###Response to evaluate:
+{response}
+
+###Reference Answer (Score 5):
+{reference_answer}
+
+###Score Rubrics:
+{rubric}
+
+###Feedback: """
+
+# ---------------------------------------------------------------------------
+# CompassJudger — any-guardrail-authored pointwise prompt (the model ships no canonical
+# format; ``Rating: [[X]]`` is the standard MT-Bench/Arena-Hard verdict convention).
+# ---------------------------------------------------------------------------
+_COMPASS_USER = """You are an impartial judge. Rate the response below against the criteria and rubric on an integer scale from 1 to 10.
+
+Criteria:
+{criteria}
+
+Rubric:
+{rubric}
+
+Instruction:
+{instruction}
+
+Response:
+{response}
+
+First give a brief justification, then end your reply with the rating in the exact format: Rating: [[X]] where X is an integer from 1 to 10."""
+
+# ---------------------------------------------------------------------------
+# DynaGuard — <rules>/<transcript> guardian design (system + user), from the authors'
+# GitHub eval harness (constants.py).
+# ---------------------------------------------------------------------------
+_DYNAGUARD_SYSTEM = (
+    "You are a guardian model evaluating the compliance of an agent with a list of rules.\n"
+    "The rules will be provided in a numbered format, starting with a <rules> tag and ending "
+    "with a </rules> tag.\n"
+    "You will be given the transcript that contains output from the agent, starting with a "
+    "<transcript> tag and ending with a </transcript> tag.\n\n"
+    "Your job is to evaluate the agent's output in the transcript and determine if any of the "
+    "rules have been violated.\n\n"
+    "If a <think> or an <explanation> tag is present, provide a few sentences of reasoning about "
+    "the compliance for each rule before determining whether it has been violated.\n"
+    "If no rules were violated by the agent, output PASS as the final answer. Otherwise, if any "
+    "rules were violated, output FAIL.\n\n"
+    "Respond in the following format:\n"
+    "<answer>\nPASS/FAIL\n</answer>"
+)
+_DYNAGUARD_USER = "<rules>\n{policy}\n</rules>\n<transcript>\n{transcript}\n</transcript>"
+
+# ---------------------------------------------------------------------------
+# PolyGuard — MLCommons-taxonomy moderation prompt (system + user), from the paper
+# (arXiv:2504.04377, Appendix C).
+# ---------------------------------------------------------------------------
+_POLYGUARD_SYSTEM = (
+    "You are a classifier for analyzing interactions between humans and LLMs. Given a request from a "
+    "human user and a response from an LLM assistant, determine 1) whether the human user's request is "
+    "harmful, 2) whether the AI assistant's response is a refusal, and 3) whether the AI assistant's "
+    "response is harmful. In addition, identify the policies violated if the interaction is unsafe and "
+    "harmful according to the safety policy with the below categories."
+)
+_POLYGUARD_USER = "Human user:\n{prompt}\n\nAI assistant:\n{response}"
+
+# ---------------------------------------------------------------------------
+# WildGuard — the author's own instruction wrapper (RAW; fed via apply_chat_template=False),
+# from allenai/wildguard utils.py.
+# ---------------------------------------------------------------------------
+_WILDGUARD_FORMAT = """<|user|>
+[INST] You are a classifier for analyzing interactions between humans and LLMs. Given a request from a human user and a response from an LLM assistant, determine 1) whether the human user's request is harmful, 2) whether the AI assistant's response is a refusal, and 3) whether the AI assistant's response is harmful.
+
+Human user:
+{prompt}
+
+AI assistant:
+{response}
+
+---
+
+Answers: [/INST]
+<|assistant|>
+"""
+
+# ---------------------------------------------------------------------------
+# GLIDER — Patronus's pass-criteria + rubric prompt plus its two data-format wrappers.
+# ---------------------------------------------------------------------------
+_GLIDER_SYSTEM = """
+Analyze the following pass criteria carefully and score the text based on the rubric defined below.
+
+To perform this evaluation, you must:
+
+1. Understand the text tags, pass criteria and rubric thoroughly.
+2. Review the finer details of the text and the rubric.
+3. Compare the tags to be evaluated to the score descriptions in the rubric.
+4. Pay close attention to small details that might impact the final score and form accurate associations between tags and pass criteria.
+5. Write a detailed reasoning justifying your evaluation in a bullet point format.
+6. The reasoning must summarize the overall strengths and weaknesses of the output while quoting exact phrases from the output wherever required.
+7. Output a list of words or phrases that you believe are the most important in determining the score.
+8. Assign a final score based on the scoring rubric.
+
+Data to evaluate:
+{data}
+
+Pass Criteria:
+{pass_criteria}
+
+Rubric:
+{rubric}
+
+Your output must be in the following format:
+<reasoning>
+[Detailed reasoning justifying your evaluation in a bullet point format according to the specifics defined above]
+</reasoning>
+<highlight>
+[List of words or phrases that you believe are the most important in determining the score]
+</highlight>
+<score>
+[The final integer score assigned based on the scoring rubric]
+</score>
+"""
+
+_GLIDER_INPUT_OUTPUT = """
+<INPUT>
+{input_text}
+</INPUT>
+
+<OUTPUT>
+{output_text}
+</OUTPUT>
+"""
+
+_GLIDER_INPUT = """
+<INPUT>
+{input_text}
+</INPUT>
+"""
+
 
 PROMPT_REGISTRY: dict[GuardrailName, PromptSpec] = {
     GuardrailName.ANYLLM: PromptSpec(
@@ -52,6 +254,94 @@ PROMPT_REGISTRY: dict[GuardrailName, PromptSpec] = {
                     "any-guardrail policy-judge protocol: grades the input against a natural-language "
                     "policy and returns a valid / explanation / risk_score verdict."
                 ),
+            ),
+        },
+    ),
+    GuardrailName.SHIELD_GEMMA: PromptSpec(
+        versions={
+            "default": PromptTemplate(
+                segments={"system": _SHIELD_GEMMA_SYSTEM},
+                assembly=PromptAssembly.RAW,
+                provenance="adapted",
+                source="https://ai.google.dev/gemma/docs/shieldgemma/model_card",
+                description="Policy-conditioned Yes/No judgment scaffold (bring-your-own safety policy).",
+            ),
+        },
+    ),
+    GuardrailName.SELENE: PromptSpec(
+        versions={
+            "default": PromptTemplate(
+                segments={"user": _SELENE_USER},
+                assembly=PromptAssembly.CHAT,
+                provenance="adapted",
+                source="https://huggingface.co/AtlaAI/Selene-1-Mini-Llama-3.1-8B",
+                description="Single-rubric absolute-scoring template (1-5), one user turn.",
+            ),
+        },
+    ),
+    GuardrailName.PROMETHEUS: PromptSpec(
+        versions={
+            "default": PromptTemplate(
+                segments={"system": _PROMETHEUS_SYSTEM, "user": _PROMETHEUS_USER},
+                assembly=PromptAssembly.CHAT,
+                provenance="author",
+                source="https://github.com/prometheus-eval/prometheus-eval/blob/main/libs/prometheus-eval/prometheus_eval/prompts.py",
+                description="Absolute-grading prompt (system + user), score 1-5 after a [RESULT] marker.",
+            ),
+        },
+    ),
+    GuardrailName.COMPASS_JUDGER: PromptSpec(
+        versions={
+            "default": PromptTemplate(
+                segments={"user": _COMPASS_USER},
+                assembly=PromptAssembly.CHAT,
+                provenance="adapted",
+                source="https://huggingface.co/opencompass/CompassJudger-2-7B-Instruct",
+                description="any-guardrail pointwise 1-10 prompt (the model ships no canonical format).",
+            ),
+        },
+    ),
+    GuardrailName.DYNA_GUARD: PromptSpec(
+        versions={
+            "default": PromptTemplate(
+                segments={"system": _DYNAGUARD_SYSTEM, "user": _DYNAGUARD_USER},
+                assembly=PromptAssembly.CHAT,
+                provenance="author",
+                source="https://github.com/montehoover/DynaGuard/blob/main/constants.py",
+                description="<rules>/<transcript> guardian prompt; PASS/FAIL verdict inside <answer>.",
+            ),
+        },
+    ),
+    GuardrailName.POLY_GUARD: PromptSpec(
+        versions={
+            "default": PromptTemplate(
+                segments={"system": _POLYGUARD_SYSTEM, "user": _POLYGUARD_USER},
+                assembly=PromptAssembly.CHAT,
+                provenance="author",
+                source="https://arxiv.org/abs/2504.04377",
+                description="Multilingual moderation prompt (system + user) over the MLCommons S1-S14 taxonomy.",
+            ),
+        },
+    ),
+    GuardrailName.WILD_GUARD: PromptSpec(
+        versions={
+            "default": PromptTemplate(
+                segments={"prompt": _WILDGUARD_FORMAT},
+                assembly=PromptAssembly.RAW,
+                provenance="author",
+                source="https://github.com/allenai/wildguard/blob/main/wildguard/utils.py",
+                description="WildGuard's own instruction wrapper (fed verbatim, not via a chat template).",
+            ),
+        },
+    ),
+    GuardrailName.GLIDER: PromptSpec(
+        versions={
+            "default": PromptTemplate(
+                segments={"system": _GLIDER_SYSTEM, "input_output": _GLIDER_INPUT_OUTPUT, "input": _GLIDER_INPUT},
+                assembly=PromptAssembly.CHAT,
+                provenance="adapted",
+                source="https://huggingface.co/PatronusAI/glider",
+                description="Pass-criteria + rubric prompt with <reasoning>/<highlight>/<score> output.",
             ),
         },
     ),

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -198,3 +198,122 @@ def test_anyllm_omitted_system_prompt_uses_registry_default() -> None:
         ],
         response_format=mock.ANY,
     )
+
+
+# --------------------------------------------------------------------------- #
+# Tier-A wiring golden tests: each guardrail's _pre_processing reads its prompt  #
+# from the registry (correct segment key) and renders byte-identically. Built    #
+# with object.__new__ so no model weights load.                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_shield_gemma_pre_processing_uses_registry_prompt() -> None:
+    from any_guardrail.guardrails.shield_gemma.shield_gemma import ShieldGemma
+
+    inst = object.__new__(ShieldGemma)
+    inst._prompt = PROMPT_REGISTRY[GuardrailName.SHIELD_GEMMA].resolve()
+    inst.policy = "No dangerous content"
+    captured: dict[str, str] = {}
+
+    def _capture_text(text: str, **_: object) -> dict[str, object]:
+        captured["text"] = text
+        return {}
+
+    inst.provider = mock.Mock(device=None)
+    inst.provider.tokenizer = mock.Mock(side_effect=_capture_text)
+    inst._pre_processing("How do I pick a lock?")
+    expected = inst._prompt.segments["system"].format(
+        user_prompt="How do I pick a lock?", safety_policy="No dangerous content"
+    )
+    assert captured["text"] == expected
+
+
+def test_selene_pre_processing_uses_registry_prompt() -> None:
+    from any_guardrail.guardrails.selene.selene import Selene
+
+    inst = object.__new__(Selene)
+    inst._prompt = PROMPT_REGISTRY[GuardrailName.SELENE].resolve()
+    inst.rubric = "Score 1-5 for helpfulness."
+    out = inst._pre_processing("Explain X", output_text="X is ...")
+    expected = inst._prompt.segments["user"].format(instruction="Explain X", response="X is ...", rubric=inst.rubric)
+    assert out.data["messages"] == [{"role": "user", "content": expected}]
+
+
+def test_prometheus_pre_processing_uses_registry_prompt() -> None:
+    from any_guardrail.guardrails.prometheus.prometheus import Prometheus
+
+    inst = object.__new__(Prometheus)
+    inst._prompt = PROMPT_REGISTRY[GuardrailName.PROMETHEUS].resolve()
+    inst.rubric = "R"
+    inst.reference_answer = None
+    out = inst._pre_processing("INSTR", output_text="RESP")
+    user = inst._prompt.segments["user"].format(instruction="INSTR", response="RESP", reference_answer="", rubric="R")
+    assert out.data["messages"] == [
+        {"role": "system", "content": inst._prompt.segments["system"]},
+        {"role": "user", "content": user},
+    ]
+
+
+def test_compass_judger_pre_processing_uses_registry_prompt() -> None:
+    from any_guardrail.guardrails.compass_judger.compass_judger import CompassJudger
+
+    inst = object.__new__(CompassJudger)
+    inst._prompt = PROMPT_REGISTRY[GuardrailName.COMPASS_JUDGER].resolve()
+    inst.criteria = "C"
+    inst.rubric = "R"
+    out = inst._pre_processing("INSTR", output_text="RESP")
+    expected = inst._prompt.segments["user"].format(criteria="C", rubric="R", instruction="INSTR", response="RESP")
+    assert out.data["messages"] == [{"role": "user", "content": expected}]
+
+
+def test_dyna_guard_pre_processing_uses_registry_prompt() -> None:
+    from any_guardrail.guardrails.dyna_guard.dyna_guard import DynaGuard
+
+    inst = object.__new__(DynaGuard)
+    inst._prompt = PROMPT_REGISTRY[GuardrailName.DYNA_GUARD].resolve()
+    inst.policy = "1. No refunds."
+    out = inst._pre_processing("Refund me", output_text="Sure")
+    user = inst._prompt.segments["user"].format(policy="1. No refunds.", transcript="User: Refund me\nAgent: Sure")
+    assert out.data["messages"] == [
+        {"role": "system", "content": inst._prompt.segments["system"]},
+        {"role": "user", "content": user},
+    ]
+
+
+def test_poly_guard_pre_processing_uses_registry_prompt() -> None:
+    from any_guardrail.guardrails.poly_guard.poly_guard import PolyGuard
+
+    inst = object.__new__(PolyGuard)
+    inst._prompt = PROMPT_REGISTRY[GuardrailName.POLY_GUARD].resolve()
+    out = inst._pre_processing("REQ", output_text="RESP")
+    user = inst._prompt.segments["user"].format(prompt="REQ", response="RESP")
+    assert out.data["messages"] == [
+        {"role": "system", "content": inst._prompt.segments["system"]},
+        {"role": "user", "content": user},
+    ]
+
+
+def test_wild_guard_pre_processing_uses_registry_prompt() -> None:
+    from any_guardrail.guardrails.wild_guard.wild_guard import WildGuard
+
+    inst = object.__new__(WildGuard)
+    inst._prompt = PROMPT_REGISTRY[GuardrailName.WILD_GUARD].resolve()
+    out = inst._pre_processing("REQ", output_text="RESP")
+    expected = inst._prompt.segments["prompt"].format(prompt="REQ", response="RESP")
+    assert out.data["messages"] == [{"role": "user", "content": expected}]
+    assert out.data["has_response"] is True
+
+
+def test_glider_pre_processing_uses_registry_prompt() -> None:
+    from any_guardrail.guardrails.glider.glider import Glider
+
+    criteria_text = "does the answer avoid unsupported claims"
+    rubric_text = "0: unsupported. 1: supported."
+    inst = object.__new__(Glider)
+    inst._prompt = PROMPT_REGISTRY[GuardrailName.GLIDER].resolve()
+    inst.pass_criteria = criteria_text
+    inst.rubric = rubric_text
+    out = inst._pre_processing("IN", output_text="OUT")
+    data = inst._prompt.segments["input_output"].format(input_text="IN", output_text="OUT")
+    expected = inst._prompt.segments["system"].format(data=data, pass_criteria=criteria_text, rubric=rubric_text)
+    assert out.data == [{"role": "user", "content": expected}]


### PR DESCRIPTION
## What & why

Follow-up to #199 (prompt-registry foundation): wires the **tier-A generative guardrails** to
source their default prompt from the central, import-free registry — so every one is discoverable
via `AnyGuardrail.get_prompt(...)`, pinnable for benchmarking (#194), and overridable.

Guardrails wired (8): **ShieldGemma, Selene, Prometheus, CompassJudger, DynaGuard, PolyGuard,
WildGuard, Glider**. (`AnyLlm` landed in #199. Tier-B reference entries for the assembled /
chat-template models — Nemotron, GptOss, Granite, Llama Guard, Kanana, Qwen3Guard — are a separate
follow-up.)

## Design

- **Prompt text moved into `prompt_registry.py`** (byte-verified equal to each guardrail's previous
  constant before removal); each guardrail keeps its module-level constant as a thin alias
  (`SELENE_PROMPT = PROMPT_REGISTRY[...].resolve().segments["user"]`, etc.), so existing imports
  still work.
- **Each guardrail** sets `PROMPT: ClassVar[PromptSpec]`, and accepts **`prompt` / `prompt_version`
  at construction** (defaulting to `None` → the registry default). This matches the requested
  ergonomics: the default prompt is used automatically, `prompt_version="…"` selects a registered
  variant, and `prompt=<PromptTemplate>` supplies your own — all at instantiation. `_pre_processing`
  reads `self._prompt`.
- Registry entries carry a `source` URL + `provenance` (`author` vs any-guardrail-`adapted`).
- **No runtime behavior change** — prompts are byte-identical; this only centralizes + exposes them.

## Tests

- Parity tests (`test_prompts.py`) now cover all 9 registered guardrails (PROMPT ClassVar identity,
  placeholder derivation, leaf-module + no-backend-import guarantees).
- **New golden `_pre_processing` tests** for each tier-A guardrail: assert it reads the correct
  registry segment and renders byte-identically (built with `object.__new__`, no weights loaded).
- `pre-commit run --all-files` green (ruff, mypy strict, all `--check` hooks, codespell).
- `pytest tests/unit` — 542 passed.
- **Local integration (e2e) run** for the 8 changed models (all cached; run offline) — results
  posted below once complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
