### PR TITLE
fix(registry): correct default_license metadata + add per-variant license field (#211)

### DIFF
--- a/schemas/guardrail_metadata.json
+++ b/schemas/guardrail_metadata.json
@@ -29,6 +29,7 @@
       "output",
       "rag_context"
     ],
+    "variant_licenses": [],
     "vendor": "Alinia AI"
   },
   "any_llm": {
@@ -59,6 +60,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "Mozilla AI"
   },
   "azure_content_safety": {
@@ -84,6 +86,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "Microsoft"
   },
   "azure_prompt_shields": {
@@ -109,6 +112,7 @@
       "input",
       "rag_context"
     ],
+    "variant_licenses": [],
     "vendor": "Microsoft"
   },
   "bedrock_guardrails": {
@@ -136,6 +140,7 @@
       "output",
       "rag_context"
     ],
+    "variant_licenses": [],
     "vendor": "Amazon"
   },
   "bielik_guard": {
@@ -161,6 +166,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "SpeakLeash / Bielik.AI"
   },
   "compass_judger": {
@@ -185,6 +191,7 @@
     "stages": [
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "OpenCompass"
   },
   "deepset": {
@@ -208,6 +215,7 @@
     "stages": [
       "input"
     ],
+    "variant_licenses": [],
     "vendor": "deepset"
   },
   "duo_guard": {
@@ -234,6 +242,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "DuoGuard"
   },
   "dyna_guard": {
@@ -260,6 +269,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "DynaGuard"
   },
   "flowjudge": {
@@ -285,6 +295,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "Flow AI"
   },
   "gli_guard": {
@@ -310,6 +321,7 @@
     "stages": [
       "input"
     ],
+    "variant_licenses": [],
     "vendor": "Fastino"
   },
   "glider": {
@@ -335,6 +347,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "Patronus AI"
   },
   "gpt_oss_safeguard": {
@@ -358,6 +371,7 @@
     "stages": [
       "input"
     ],
+    "variant_licenses": [],
     "vendor": "OpenAI"
   },
   "granite_guardian": {
@@ -392,6 +406,7 @@
       "output",
       "rag_context"
     ],
+    "variant_licenses": [],
     "vendor": "IBM"
   },
   "harm_guard": {
@@ -419,6 +434,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "hbseong"
   },
   "injec_guard": {
@@ -442,6 +458,7 @@
     "stages": [
       "input"
     ],
+    "variant_licenses": [],
     "vendor": "leolee99"
   },
   "jasper": {
@@ -465,6 +482,7 @@
     "stages": [
       "input"
     ],
+    "variant_licenses": [],
     "vendor": "JasperLS"
   },
   "kanana_safeguard": {
@@ -491,6 +509,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "Kakao"
   },
   "lakera_guard": {
@@ -516,6 +535,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "Lakera"
   },
   "lettuce_detect": {
@@ -544,6 +564,7 @@
       "output",
       "rag_context"
     ],
+    "variant_licenses": [],
     "vendor": "KRLabs"
   },
   "llama_guard": {
@@ -569,6 +590,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "Meta"
   },
   "nemotron_content_safety": {
@@ -594,6 +616,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "NVIDIA"
   },
   "off_topic": {
@@ -619,6 +642,7 @@
     "stages": [
       "input"
     ],
+    "variant_licenses": [],
     "vendor": "GovTech Singapore"
   },
   "openai_moderation": {
@@ -644,6 +668,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "OpenAI"
   },
   "pangolin": {
@@ -667,6 +692,7 @@
     "stages": [
       "input"
     ],
+    "variant_licenses": [],
     "vendor": "dcarpintero"
   },
   "patronus": {
@@ -699,6 +725,7 @@
       "output",
       "rag_context"
     ],
+    "variant_licenses": [],
     "vendor": "Patronus AI"
   },
   "poly_guard": {
@@ -724,6 +751,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "ToxicityPrompts"
   },
   "prometheus": {
@@ -748,6 +776,7 @@
     "stages": [
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "KAIST / prometheus-eval"
   },
   "prompt_guard": {
@@ -771,6 +800,7 @@
     "stages": [
       "input"
     ],
+    "variant_licenses": [],
     "vendor": "Meta"
   },
   "protectai": {
@@ -794,6 +824,7 @@
     "stages": [
       "input"
     ],
+    "variant_licenses": [],
     "vendor": "ProtectAI"
   },
   "qwen3_guard": {
@@ -820,6 +851,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "Qwen"
   },
   "qwen3_guard_stream": {
@@ -846,6 +878,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "Qwen"
   },
   "selene": {
@@ -870,6 +903,7 @@
     "stages": [
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "Atla"
   },
   "sentinel": {
@@ -893,6 +927,7 @@
     "stages": [
       "input"
     ],
+    "variant_licenses": [],
     "vendor": "Qualifire"
   },
   "shield_gemma": {
@@ -916,6 +951,7 @@
     "stages": [
       "input"
     ],
+    "variant_licenses": [],
     "vendor": "Google"
   },
   "watsonx_guardian": {
@@ -945,6 +981,7 @@
       "output",
       "rag_context"
     ],
+    "variant_licenses": [],
     "vendor": "IBM"
   },
   "wild_guard": {
@@ -971,6 +1008,7 @@
       "input",
       "output"
     ],
+    "variant_licenses": [],
     "vendor": "Allen Institute for AI"
   }
 }

--- a/schemas/guardrail_metadata.json
+++ b/schemas/guardrail_metadata.json
@@ -199,7 +199,7 @@
     "categories": [
       "prompt_injection"
     ],
-    "default_license": "cc-by-4.0",
+    "default_license": "mit",
     "description": "Binary prompt-injection classifier.",
     "display_name": "Deepset",
     "multilingual": false,
@@ -242,7 +242,20 @@
       "input",
       "output"
     ],
-    "variant_licenses": [],
+    "variant_licenses": [
+      {
+        "license": "apache-2.0",
+        "model_id": "DuoGuard/DuoGuard-0.5B"
+      },
+      {
+        "license": "apache-2.0",
+        "model_id": "DuoGuard/DuoGuard-1.5B-transfer"
+      },
+      {
+        "license": "llama-3.2",
+        "model_id": "DuoGuard/DuoGuard-1B-Llama-3.2-transfer"
+      }
+    ],
     "vendor": "DuoGuard"
   },
   "dyna_guard": {
@@ -572,7 +585,7 @@
     "categories": [
       "content_safety"
     ],
-    "default_license": "llama-3.1",
+    "default_license": "llama-3.2",
     "description": "Decoder-LLM safety classifier judging prompts and responses against the 14-category MLCommons hazard taxonomy.",
     "display_name": "Llama Guard",
     "multilingual": true,
@@ -590,7 +603,20 @@
       "input",
       "output"
     ],
-    "variant_licenses": [],
+    "variant_licenses": [
+      {
+        "license": "llama-3.2",
+        "model_id": "meta-llama/Llama-Guard-3-1B"
+      },
+      {
+        "license": "llama-3.1",
+        "model_id": "meta-llama/Llama-Guard-3-8B"
+      },
+      {
+        "license": "llama-4",
+        "model_id": "meta-llama/Llama-Guard-4-12B"
+      }
+    ],
     "vendor": "Meta"
   },
   "nemotron_content_safety": {
@@ -598,7 +624,7 @@
     "categories": [
       "content_safety"
     ],
-    "default_license": "nvidia-open-model",
+    "default_license": "gemma",
     "description": "Reasoning safety classifier covering a 22-category content-safety taxonomy.",
     "display_name": "Nemotron Content Safety",
     "multilingual": false,
@@ -733,7 +759,7 @@
     "categories": [
       "content_safety"
     ],
-    "default_license": "apache-2.0",
+    "default_license": "mrl",
     "description": "Multilingual safety-moderation judge reporting request harm, response harm, and refusal across 17 languages.",
     "display_name": "PolyGuard",
     "multilingual": true,
@@ -751,7 +777,20 @@
       "input",
       "output"
     ],
-    "variant_licenses": [],
+    "variant_licenses": [
+      {
+        "license": "mrl",
+        "model_id": "ToxicityPrompts/PolyGuard-Ministral"
+      },
+      {
+        "license": "apache-2.0",
+        "model_id": "ToxicityPrompts/PolyGuard-Qwen"
+      },
+      {
+        "license": "apache-2.0",
+        "model_id": "ToxicityPrompts/PolyGuard-Qwen-Smol"
+      }
+    ],
     "vendor": "ToxicityPrompts"
   },
   "prometheus": {
@@ -776,7 +815,24 @@
     "stages": [
       "output"
     ],
-    "variant_licenses": [],
+    "variant_licenses": [
+      {
+        "license": "llama-2",
+        "model_id": "prometheus-eval/prometheus-13b-v1.0"
+      },
+      {
+        "license": "llama-2",
+        "model_id": "prometheus-eval/prometheus-7b-v1.0"
+      },
+      {
+        "license": "apache-2.0",
+        "model_id": "prometheus-eval/prometheus-7b-v2.0"
+      },
+      {
+        "license": "apache-2.0",
+        "model_id": "prometheus-eval/prometheus-8x7b-v2.0"
+      }
+    ],
     "vendor": "KAIST / prometheus-eval"
   },
   "prompt_guard": {
@@ -886,7 +942,7 @@
     "categories": [
       "general_judge"
     ],
-    "default_license": "apache-2.0",
+    "default_license": "llama-3.1",
     "description": "General-purpose LLM judge grading a response against a user-defined 1-5 rubric.",
     "display_name": "Selene 1 Mini",
     "multilingual": false,
@@ -911,7 +967,7 @@
     "categories": [
       "prompt_injection"
     ],
-    "default_license": "apache-2.0",
+    "default_license": "elastic-2.0",
     "description": "Binary prompt-injection classifier.",
     "display_name": "Sentinel",
     "multilingual": false,

--- a/src/any_guardrail/registry.py
+++ b/src/any_guardrail/registry.py
@@ -19,6 +19,7 @@ from any_guardrail.taxonomy import (
     GuardrailMetadata,
     GuardrailStage,
     OutputShape,
+    VariantLicense,
 )
 
 GUARDRAIL_METADATA: dict[GuardrailName, GuardrailMetadata] = {
@@ -65,7 +66,7 @@ GUARDRAIL_METADATA: dict[GuardrailName, GuardrailMetadata] = {
         output_shapes=frozenset({OutputShape.BINARY, OutputShape.SCORE}),
         backend=BackendType.LOCAL_ENCODER,
         vendor="deepset",
-        default_license="cc-by-4.0",
+        default_license="mit",
     ),
     GuardrailName.DUOGUARD: GuardrailMetadata(
         description="Multilingual multi-label safety classifier scoring text across 12 harm categories including jailbreak prompts.",
@@ -79,7 +80,13 @@ GUARDRAIL_METADATA: dict[GuardrailName, GuardrailMetadata] = {
         backend=BackendType.LOCAL_ENCODER,
         multilingual=True,
         vendor="DuoGuard",
+        # Default (0.5B) and 1.5B are Apache-2.0 (Qwen2.5 base); the 1B transfer carries Llama 3.2 terms.
         default_license="apache-2.0",
+        variant_licenses=(
+            VariantLicense(model_id="DuoGuard/DuoGuard-0.5B", license="apache-2.0"),
+            VariantLicense(model_id="DuoGuard/DuoGuard-1B-Llama-3.2-transfer", license="llama-3.2"),
+            VariantLicense(model_id="DuoGuard/DuoGuard-1.5B-transfer", license="apache-2.0"),
+        ),
     ),
     GuardrailName.FLOWJUDGE: GuardrailMetadata(
         description="Local LLM judge scoring text against user-defined criteria, metrics, and rubrics.",
@@ -217,7 +224,8 @@ GUARDRAIL_METADATA: dict[GuardrailName, GuardrailMetadata] = {
         output_shapes=frozenset({OutputShape.BINARY, OutputShape.SCORE}),
         backend=BackendType.LOCAL_ENCODER,
         vendor="Qualifire",
-        default_license="apache-2.0",
+        # Gated on HuggingFace and released under Elastic License 2.0; redistribution not cleared.
+        default_license="elastic-2.0",
     ),
     GuardrailName.SHIELD_GEMMA: GuardrailMetadata(
         description="Policy-conditioned safety classifier that judges a prompt against a user-supplied policy via Yes/No token logits.",
@@ -242,7 +250,13 @@ GUARDRAIL_METADATA: dict[GuardrailName, GuardrailMetadata] = {
         multilingual=True,
         multimodal=True,
         vendor="Meta",
-        default_license="llama-3.1",
+        # Default is Llama-Guard-3-1B (Llama 3.2); the 8B and 4-12B variants carry different Llama terms.
+        default_license="llama-3.2",
+        variant_licenses=(
+            VariantLicense(model_id="meta-llama/Llama-Guard-3-1B", license="llama-3.2"),
+            VariantLicense(model_id="meta-llama/Llama-Guard-3-8B", license="llama-3.1"),
+            VariantLicense(model_id="meta-llama/Llama-Guard-4-12B", license="llama-4"),
+        ),
     ),
     GuardrailName.AZURE_CONTENT_SAFETY: GuardrailMetadata(
         description="Hosted moderation of text and images across hate, sexual, self-harm, and violence categories with 0-7 severity scores.",
@@ -367,7 +381,9 @@ GUARDRAIL_METADATA: dict[GuardrailName, GuardrailMetadata] = {
         backend=BackendType.LOCAL_DECODER,
         optional_validate_kwargs=frozenset({"output_text"}),
         vendor="NVIDIA",
-        default_license="nvidia-open-model",
+        # Fine-tune of google/gemma-3-4b-it: NVIDIA Open Model License + Gemma Terms of Use both apply;
+        # Gemma is the binding constraint for redistribution.
+        default_license="gemma",
     ),
     GuardrailName.POLY_GUARD: GuardrailMetadata(
         description="Multilingual safety-moderation judge reporting request harm, response harm, and refusal across 17 languages.",
@@ -380,7 +396,14 @@ GUARDRAIL_METADATA: dict[GuardrailName, GuardrailMetadata] = {
         optional_validate_kwargs=frozenset({"output_text"}),
         multilingual=True,
         vendor="ToxicityPrompts",
-        default_license="apache-2.0",
+        # Default is PolyGuard-Ministral, under the non-commercial Mistral Research License (MRL);
+        # only the Qwen variants are Apache-2.0.
+        default_license="mrl",
+        variant_licenses=(
+            VariantLicense(model_id="ToxicityPrompts/PolyGuard-Ministral", license="mrl"),
+            VariantLicense(model_id="ToxicityPrompts/PolyGuard-Qwen", license="apache-2.0"),
+            VariantLicense(model_id="ToxicityPrompts/PolyGuard-Qwen-Smol", license="apache-2.0"),
+        ),
     ),
     GuardrailName.KANANA_SAFEGUARD: GuardrailMetadata(
         description="Korean safety decoder models covering harmful content, legal risk, and prompt attacks.",
@@ -416,7 +439,14 @@ GUARDRAIL_METADATA: dict[GuardrailName, GuardrailMetadata] = {
         backend=BackendType.LOCAL_DECODER,
         optional_validate_kwargs=frozenset({"output_text"}),
         vendor="KAIST / prometheus-eval",
+        # v2 (default) is Apache-2.0 (Mistral base); the v1 checkpoints carry Llama 2 terms.
         default_license="apache-2.0",
+        variant_licenses=(
+            VariantLicense(model_id="prometheus-eval/prometheus-7b-v2.0", license="apache-2.0"),
+            VariantLicense(model_id="prometheus-eval/prometheus-8x7b-v2.0", license="apache-2.0"),
+            VariantLicense(model_id="prometheus-eval/prometheus-7b-v1.0", license="llama-2"),
+            VariantLicense(model_id="prometheus-eval/prometheus-13b-v1.0", license="llama-2"),
+        ),
     ),
     GuardrailName.COMPASS_JUDGER: GuardrailMetadata(
         description="Generalist LLM judge that scores a response against user-defined criteria and rubric on a 1-10 scale.",
@@ -440,7 +470,8 @@ GUARDRAIL_METADATA: dict[GuardrailName, GuardrailMetadata] = {
         backend=BackendType.LOCAL_DECODER,
         optional_validate_kwargs=frozenset({"output_text"}),
         vendor="Atla",
-        default_license="apache-2.0",
+        # apache-2.0 tag is a base carryover; the Llama-3.1-8B base governs.
+        default_license="llama-3.1",
     ),
     GuardrailName.LETTUCE_DETECT: GuardrailMetadata(
         description="Token/span-level RAG hallucination detector.",

--- a/src/any_guardrail/taxonomy.py
+++ b/src/any_guardrail/taxonomy.py
@@ -106,6 +106,26 @@ class BackendType(StrEnum):
     """A third-party Python library invoked directly (its own optional extra)."""
 
 
+class VariantLicense(BaseModel):
+    """License governing a single model variant of a guardrail.
+
+    Used where a guardrail's ``SUPPORTED_MODELS`` span several base models with
+    different governing licenses (e.g. Llama Guard's 3.2 / 3.1 / 4 variants, or
+    PolyGuard's non-commercial Ministral vs Apache Qwen variants), so a single
+    ``default_license`` string cannot capture per-variant redistribution terms.
+    Instances are frozen, so a ``tuple`` of them keeps :class:`GuardrailMetadata`
+    hashable.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    model_id: str
+    """The variant's model ID (one of the guardrail's ``SUPPORTED_MODELS``)."""
+
+    license: str
+    """SPDX-ish license governing this variant (e.g. ``"llama-3.2"``, ``"mrl"``, ``"apache-2.0"``)."""
+
+
 class GuardrailMetadata(BaseModel):
     """Static, queryable capability metadata for a single guardrail.
 
@@ -160,7 +180,14 @@ class GuardrailMetadata(BaseModel):
     """Organization that produced the model/service (e.g. ``"IBM"``, ``"Meta"``)."""
 
     default_license: str
-    """SPDX-ish license of the default model/service (e.g. ``"apache-2.0"``, ``"proprietary"``)."""
+    """SPDX-ish license of the default model/service (i.e. of ``SUPPORTED_MODELS[0]``;
+    e.g. ``"apache-2.0"``, ``"proprietary"``). See ``variant_licenses`` for the per-variant breakdown."""
+
+    variant_licenses: tuple[VariantLicense, ...] = ()
+    """Per-variant licenses, for guardrails whose ``SUPPORTED_MODELS`` span base models with
+    different governing licenses (empty when ``default_license`` covers every variant). Each entry's
+    ``model_id`` is one of the guardrail's ``SUPPORTED_MODELS``. This is the redistribution-governing
+    metadata a downstream consumer reads to decide per-variant eligibility."""
 
     @model_validator(mode="after")
     def _primary_in_categories(self) -> Self:
@@ -184,3 +211,11 @@ class GuardrailMetadata(BaseModel):
         stages, output_shapes); each element is stringified to its value explicitly.
         """
         return sorted(str(member) for member in value)
+
+    @field_serializer("variant_licenses")
+    def _serialize_variant_licenses(self, value: tuple[VariantLicense, ...]) -> list[dict[str, str]]:
+        """Emit per-variant licenses as a ``model_id``-sorted list so JSON export is deterministic."""
+        return [
+            {"model_id": variant.model_id, "license": variant.license}
+            for variant in sorted(value, key=lambda v: v.model_id)
+        ]

--- a/src/any_guardrail/taxonomy.py
+++ b/src/any_guardrail/taxonomy.py
@@ -180,8 +180,10 @@ class GuardrailMetadata(BaseModel):
     """Organization that produced the model/service (e.g. ``"IBM"``, ``"Meta"``)."""
 
     default_license: str
-    """SPDX-ish license of the default model/service (i.e. of ``SUPPORTED_MODELS[0]``;
-    e.g. ``"apache-2.0"``, ``"proprietary"``). See ``variant_licenses`` for the per-variant breakdown."""
+    """SPDX-ish license of the guardrail's default model or service: the license of
+    ``SUPPORTED_MODELS[0]`` for model-backed guardrails, or of the service/library itself for
+    hosted-API and library-wrapped guardrails (e.g. ``"apache-2.0"``, ``"proprietary"``). See
+    ``variant_licenses`` for the per-variant breakdown."""
 
     variant_licenses: tuple[VariantLicense, ...] = ()
     """Per-variant licenses, for guardrails whose ``SUPPORTED_MODELS`` span base models with

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -112,6 +112,35 @@ def test_primary_category_in_categories(name: GuardrailName) -> None:
     assert meta.primary_category in meta.categories
 
 
+@pytest.mark.parametrize("name", ALL_NAMES, ids=lambda n: n.value)
+def test_default_license_non_empty(name: GuardrailName) -> None:
+    """Every guardrail records a non-empty default_license (issue #211)."""
+    assert GUARDRAIL_METADATA[name].default_license, f"{name.value}: default_license must be non-empty"
+
+
+@pytest.mark.parametrize("name", ALL_NAMES, ids=lambda n: n.value)
+def test_variant_licenses_reference_supported_models(name: GuardrailName) -> None:
+    """Each per-variant license points at a real SUPPORTED_MODELS entry and names a license (issue #211)."""
+    meta = GUARDRAIL_METADATA[name]
+    if not meta.variant_licenses:
+        return
+    supported = set(_guardrail_class(name).SUPPORTED_MODELS)
+    seen: set[str] = set()
+    for variant in meta.variant_licenses:
+        assert variant.model_id in supported, f"{name.value}: variant {variant.model_id!r} not in SUPPORTED_MODELS"
+        assert variant.license, f"{name.value}: variant {variant.model_id!r} has an empty license"
+        assert variant.model_id not in seen, f"{name.value}: duplicate variant {variant.model_id!r}"
+        seen.add(variant.model_id)
+
+
+def test_variant_licenses_serialize_sorted_by_model_id() -> None:
+    """The variant_licenses JSON export is deterministically sorted by model_id (issue #211)."""
+    for name in ALL_NAMES:
+        dumped = GUARDRAIL_METADATA[name].model_dump(mode="json")["variant_licenses"]
+        model_ids = [entry["model_id"] for entry in dumped]
+        assert model_ids == sorted(model_ids), f"{name.value}: variant_licenses not sorted by model_id"
+
+
 def test_metadata_is_frozen() -> None:
     """GuardrailMetadata instances are immutable."""
     meta = next(iter(GUARDRAIL_METADATA.values()))

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -115,7 +115,7 @@ def test_primary_category_in_categories(name: GuardrailName) -> None:
 @pytest.mark.parametrize("name", ALL_NAMES, ids=lambda n: n.value)
 def test_default_license_non_empty(name: GuardrailName) -> None:
     """Every guardrail records a non-empty default_license (issue #211)."""
-    assert GUARDRAIL_METADATA[name].default_license, f"{name.value}: default_license must be non-empty"
+    assert GUARDRAIL_METADATA[name].default_license.strip(), f"{name.value}: default_license must be non-empty"
 
 
 @pytest.mark.parametrize("name", ALL_NAMES, ids=lambda n: n.value)
@@ -128,7 +128,7 @@ def test_variant_licenses_reference_supported_models(name: GuardrailName) -> Non
     seen: set[str] = set()
     for variant in meta.variant_licenses:
         assert variant.model_id in supported, f"{name.value}: variant {variant.model_id!r} not in SUPPORTED_MODELS"
-        assert variant.license, f"{name.value}: variant {variant.model_id!r} has an empty license"
+        assert variant.license.strip(), f"{name.value}: variant {variant.model_id!r} has an empty license"
         assert variant.model_id not in seen, f"{name.value}: duplicate variant {variant.model_id!r}"
         seen.add(variant.model_id)
 


### PR DESCRIPTION
## Summary

Corrects the `default_license` values flagged by the Open-Weight license audit and adds a structured **per-variant license field** so downstream consumers (Otari's metadata surface) get accurate, redistribution-governing licenses per model variant.

Closes #211.

## Changes

**`taxonomy.py`** — new frozen `VariantLicense` model (`model_id`, `license`) + a hashable `variant_licenses: tuple[VariantLicense, ...]` field on `GuardrailMetadata`. A `model_id`-sorted field serializer keeps the JSON export deterministic. `GuardrailMetadata` stays frozen/hashable (tuple of frozen models).

**`registry.py`** — corrected `default_license` and populated `variant_licenses`:

| Guardrail | Before | After (`default_license`) | Per-variant |
|---|---|---|---|
| Deepset | `cc-by-4.0` | `mit` | — |
| Sentinel | `apache-2.0` | `elastic-2.0` (gated) | — |
| Nemotron Content Safety | `nvidia-open-model` | `gemma` (Gemma-3 fine-tune; Gemma terms bind) | — |
| Selene | `apache-2.0` | `llama-3.1` (base carryover) | — |
| Llama Guard | `llama-3.1` | `llama-3.2` (default = 3-1B) | 3-1B→llama-3.2, 3-8B→llama-3.1, 4-12B→llama-4 |
| PolyGuard | `apache-2.0` | `mrl` (default = Ministral, non-commercial) | Ministral→mrl, Qwen/Qwen-Smol→apache-2.0 |
| Prometheus | `apache-2.0` | `apache-2.0` (v2 default) | v2→apache-2.0, v1→llama-2 |
| DuoGuard | `apache-2.0` | `apache-2.0` (0.5B/1.5B) | 1B-Llama-3.2-transfer→llama-3.2 (Meta terms) |

**`schemas/guardrail_metadata.json`** — regenerated export.

**`tests/unit/test_metadata.py`** — new invariants: `default_license` non-empty; every `variant_licenses.model_id` ∈ `SUPPORTED_MODELS`; export sorted by `model_id`.

License identifiers were desk-checked against each model card (Deepset MIT; Llama-Guard-3-1B `llama3.2`; Nemotron = google/gemma-3-4b-it fine-tune under NVIDIA Open Model License + Gemma Terms; Sentinel gated/`other`).

## Verification

- `pytest tests/unit/test_metadata.py` — 243 passed
- `pytest tests/unit` — 667 passed
- `pre-commit run --all-files` scope: ruff, ruff-format, mypy (strict), and the `guardrail-metadata-json` / catalog / SUMMARY `--check` hooks all pass.

## Work required outside this repo

None — this is a self-contained metadata correction. (Precise SPDX-ish identifiers were confirmed against the public model cards above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)