### PR TITLE
fix: packaging & discovery robustness (py.typed, broken pangolin variant, get_all_supported_models)

### DIFF
--- a/docs/api/guardrails/alinia.md
+++ b/docs/api/guardrails/alinia.md
@@ -1,6 +1,6 @@
 # Alinia
 
-Alinia — hosted content-moderation and safety-detection API with configurable detection policies (Alinia AI).
+Hosted content-moderation and safety-detection API with configurable detection policies.
 
 Sends a text input or a full conversation to the Alinia API, which runs whichever detections
 you enable via ``detection_config`` (e.g. ``{"security": True}`` for prompt-injection /

--- a/docs/api/guardrails/any-llm.md
+++ b/docs/api/guardrails/any-llm.md
@@ -1,6 +1,6 @@
 # AnyLlm
 
-AnyLlm — policy-based LLM judge that grades text against a natural-language policy using any LLM provider supported by any-llm.
+Policy-based LLM judge that grades text against a natural-language policy using an LLM provider.
 
 Wraps ``any_llm.completion`` with structured output: the judge model receives your policy
 inside a system prompt and must return a boolean verdict, an explanation, and a risk score.
@@ -36,6 +36,7 @@ Validate the `input_text` against the given `policy`.
 | `input_text` | `str` | Yes | — | The text to validate (a single string; sent as the user message). |
 | `policy` | `str` | Yes | — | Natural-language policy to validate against, e.g. ``"The text must not request or contain personal data."``. Substituted into the system prompt's ``{policy}`` placeholder. |
 | `model_id` | `str` | No | `"openai:gpt-5-nano"` | The judge model in any-llm's ``provider:model`` format, e.g. ``"openai:gpt-5-nano"`` (default) or ``"mistral:mistral-small-latest"``. The model must support structured output. |
-| `system_prompt` | `str` | No | `"You are a guardrail designed to ensure that the input text …"` | The system prompt to use. Expected to have a `{policy}` placeholder and to instruct the model to return the ``valid`` / ``explanation`` / ``risk_score`` fields of :class:`GuardrailOutputAnyLLM`. |
+| `system_prompt` | `str | None` | No | `None` | Override the system prompt. Defaults to ``None``, which uses the registry default (:data:`DEFAULT_SYSTEM_PROMPT`) — or the version selected by ``prompt_version``. A supplied prompt should have a ``{policy}`` placeholder and instruct the model to return the ``valid`` / ``explanation`` / ``risk_score`` fields of :class:`GuardrailOutputAnyLLM`. |
+| `prompt_version` | `str | None` | No | `None` | Registered prompt version to use when ``system_prompt`` is not given. Defaults to ``None`` (the default version). See :meth:`any_guardrail.AnyGuardrail.list_prompt_versions`. |
 
 **Returns:** `GuardrailOutput`

--- a/docs/api/guardrails/azure-content-safety.md
+++ b/docs/api/guardrails/azure-content-safety.md
@@ -1,6 +1,6 @@
 # AzureContentSafety
 
-Azure AI Content Safety — hosted moderation of text and images across hate, sexual, self-harm, and violence categories with 0-7 severity scores (Microsoft).
+Hosted moderation of text and images across hate, sexual, self-harm, and violence categories with 0-7 severity scores.
 
 Calls the Azure AI Content Safety ``analyze_text`` / ``analyze_image`` APIs. ``validate``
 takes a single string: plain text is sent to text analysis, while a string that is an

--- a/docs/api/guardrails/azure-prompt-shields.md
+++ b/docs/api/guardrails/azure-prompt-shields.md
@@ -1,6 +1,6 @@
 # AzurePromptShields
 
-Azure AI Prompt Shields — hosted detector for direct (user prompt) and indirect (document-borne) prompt-injection and jailbreak attacks (Microsoft).
+Hosted detector for direct (user prompt) and indirect (document-borne) prompt-injection and jailbreak attacks.
 
 Prompt Shields is a service from Azure AI Content Safety that detects prompt-injection
 and jailbreak attacks against LLM applications. It supports two attack surfaces:

--- a/docs/api/guardrails/bedrock-guardrails.md
+++ b/docs/api/guardrails/bedrock-guardrails.md
@@ -1,6 +1,6 @@
 # BedrockGuardrails
 
-AWS Bedrock Guardrails — hosted, configurable moderation via the ApplyGuardrail API covering content filters, denied topics, PII, word filters, and contextual grounding (Amazon).
+Hosted, configurable moderation covering content filters, denied topics, PII, word filters, and contextual grounding.
 
 Provides a uniform interface to AWS Bedrock Guardrails — a unified, FM-agnostic
 policy platform covering content moderation, prompt-injection / denied-topic

--- a/docs/api/guardrails/bielik-guard.md
+++ b/docs/api/guardrails/bielik-guard.md
@@ -1,6 +1,6 @@
 # BielikGuard
 
-Bielik Guard — Polish multi-label safety classifier (SpeakLeash / Bielik.AI).
+Polish multi-label safety classifier.
 
 Encoder classifier that emits an independent probability (sigmoid) for each of five Polish
 safety categories: Hate/Aggression, Vulgarities, Sexual Content, Crime, and Self-Harm. It

--- a/docs/api/guardrails/compass-judger.md
+++ b/docs/api/guardrails/compass-judger.md
@@ -1,6 +1,6 @@
 # CompassJudger
 
-CompassJudger — generalist LLM judge that scores a response against user-defined criteria and rubric on a 1-10 scale (OpenCompass).
+Generalist LLM judge that scores a response against user-defined criteria and rubric on a 1-10 scale.
 
 Decoder-LLM judge from the OpenCompass evaluation ecosystem. CompassJudger has no
 canonical pointwise output format, so this guardrail wraps the inputs in a fixed
@@ -56,6 +56,8 @@ For more information, see:
 | `higher_is_better` | `bool` | No | `True` | Whether higher ratings mean better text. Defaults to ``True``. |
 | `model_id` | `str | None` | No | `None` | Optional HuggingFace model ID; must be one of ``SUPPORTED_MODELS``. Defaults to ``opencompass/CompassJudger-2-7B-Instruct``. |
 | `provider` | `Provider[dict[str, Any], dict[str, Any]] | None` | No | `None` | Optional pre-configured provider (e.g. a ``LlamafileProvider`` or a customized ``HuggingFaceProvider``). Defaults to a ``HuggingFaceProvider`` loading a causal LM. HuggingFace-backed loads force the SDPA attention kernel because CompassJudger-2's config requests flash_attention_2, which is unavailable on CPU/MPS. |
+| `prompt` | `PromptTemplate | None` | No | `None` | Optional prompt-template override, used as-is (must fill ``{criteria}`` / ``{rubric}`` / ``{instruction}`` / ``{response}``). Defaults to ``None`` — the registry default, or the version named by ``prompt_version``. |
+| `prompt_version` | `str | None` | No | `None` | Registered prompt version to use when ``prompt`` is not given. Defaults to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``. |
 
 Initialize the CompassJudger guardrail.
 

--- a/docs/api/guardrails/deepset.md
+++ b/docs/api/guardrails/deepset.md
@@ -1,6 +1,6 @@
 # Deepset
 
-Deepset — binary prompt-injection classifier built on DeBERTa-v3-base (deepset).
+Binary prompt-injection classifier.
 
 Encoder sequence classifier that labels a text as ``LEGIT`` or ``INJECTION``.
 Feed it the raw user prompt (or any untrusted text such as retrieved snippets);

--- a/docs/api/guardrails/duo-guard.md
+++ b/docs/api/guardrails/duo-guard.md
@@ -1,6 +1,6 @@
 # DuoGuard
 
-DuoGuard — multilingual multi-label safety classifier scoring text across 12 harm categories including jailbreak prompts.
+Multilingual multi-label safety classifier scoring text across 12 harm categories including jailbreak prompts.
 
 DuoGuard is a compact (0.5B-1.5B) classifier built on Qwen 2.5 and Llama 3.2 backbones,
 trained with a two-player reinforcement-learning framework in which a generator and the

--- a/docs/api/guardrails/dyna-guard.md
+++ b/docs/api/guardrails/dyna-guard.md
@@ -1,6 +1,6 @@
 # DynaGuard
 
-DynaGuard — dynamic guardian model evaluating conversation compliance with user-defined policies.
+Dynamic guardian model evaluating conversation compliance with user-defined policies.
 
 A decoder-LLM guardian model (University of Maryland / Capital One) that checks a
 conversation transcript against a bring-your-own ``policy`` — a numbered list of
@@ -53,6 +53,8 @@ For more information, see:
 | `think` | `bool` | No | `False` | If ``True``, request chain-of-thought reasoning before the verdict, which raises the generation token budget and latency. Defaults to ``False``. |
 | `model_id` | `str | None` | No | `None` | Optional HuggingFace model ID. Must be one of ``SUPPORTED_MODELS``; defaults to ``tomg-group-umd/DynaGuard-8B``. |
 | `provider` | `Provider[dict[str, Any], dict[str, Any]] | None` | No | `None` | Optional pre-configured provider. Defaults to a ``HuggingFaceProvider`` loading the model as a causal LM. When a ``HuggingFaceProvider`` is supplied, it is loaded with ``model_class=AutoModelForCausalLM`` / ``tokenizer_class=AutoTokenizer``. |
+| `prompt` | `PromptTemplate | None` | No | `None` | Optional prompt-template override, used as-is (system prompt plus a user template filling ``{policy}`` / ``{transcript}``). Defaults to ``None`` — the registry default, or the version named by ``prompt_version``. |
+| `prompt_version` | `str | None` | No | `None` | Registered prompt version to use when ``prompt`` is not given. Defaults to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``. |
 
 Initialize the DynaGuard guardrail.
 

--- a/docs/api/guardrails/flowjudge.md
+++ b/docs/api/guardrails/flowjudge.md
@@ -1,6 +1,6 @@
 # Flowjudge
 
-Flow Judge — local LLM judge scoring text against user-defined criteria, metrics, and rubrics via the flow-judge library (Flow AI).
+Local LLM judge scoring text against user-defined criteria, metrics, and rubrics.
 
 Flow Judge wraps Flow AI's ``flow-judge`` library and its 3.8B evaluator LLM
 (``flowaicom/Flow-Judge-v0.1``, fine-tuned from Phi-3.5-mini). Unlike most guardrails it

--- a/docs/api/guardrails/gli-guard.md
+++ b/docs/api/guardrails/gli-guard.md
@@ -1,6 +1,6 @@
 # GliGuard
 
-GLiGuard — schema-driven safety, toxicity, jailbreak, and refusal detector built on GLiNER2 (Fastino).
+Schema-driven safety, toxicity, jailbreak, and refusal detector.
 
 Wraps the ``gliner2`` library to run a 300M GLiNER2 encoder that classifies a single text
 across four tasks in one pass, driven by ``GLIGUARD_SCHEMA``:

--- a/docs/api/guardrails/gli-ner-pii.md
+++ b/docs/api/guardrails/gli-ner-pii.md
@@ -59,6 +59,6 @@ Detect PII spans in ``input_text`` and emit a redacted copy.
 | `input_text` | `str` | Yes | — | The text to scan for PII. A single string. |
 | `entity_types` | `list[str] | None` | No | `None` | PII entity types to detect. Defaults to ``DEFAULT_PII_ENTITIES``. |
 | `threshold` | `float | None` | No | `None` | Confidence threshold for this call. Defaults to the instance ``threshold``. |
-| `redaction_placeholder` | `str` | No | `"[REDACTED_{label}]"` | Format string used to replace each detected span in ``modified_text``; ``{label}`` is substituted with the upper-cased entity type (e.g. ``"[REDACTED_EMAIL]"``). |
+| `redaction_placeholder` | `str` | No | `"[REDACTED_{label}]"` | Template used to replace each detected span in ``modified_text``; the substring ``{label}`` is replaced with the upper-cased entity type (e.g. ``"[REDACTED_EMAIL]"``). Any other braces are kept literal, so an arbitrary placeholder never raises. |
 
 **Returns:** `GuardrailOutput`

--- a/docs/api/guardrails/glider.md
+++ b/docs/api/guardrails/glider.md
@@ -1,6 +1,6 @@
 # Glider
 
-GLIDER — prompt-based LLM judge that grades text against user-supplied pass criteria and rubric, returning reasoning and highlighted phrases (Patronus AI).
+Prompt-based LLM judge that grades text against user-supplied pass criteria and rubric, returning reasoning and highlighted phrases.
 
 GLIDER is a compact (3B) evaluator LLM fine-tuned to score arbitrary text on
 arbitrary user-defined criteria. Each call wraps the text in GLIDER's evaluation
@@ -54,6 +54,8 @@ Raises:
 | `provider` | `Provider[dict[str, Any], dict[str, Any]] | None` | No | `None` | Reserved for future extensibility; currently unused. GLIDER runs through a ``transformers`` text-generation pipeline instead. |
 | `higher_is_better` | `bool` | No | `True` | Whether higher rubric scores mean better/passing text. Set to ``False`` for rubrics where higher scores mean worse text (e.g. a severity scale). |
 | `score_range` | `tuple[int, int] | None` | No | `None` | Optional ``(min, max)`` bounds of the rubric scale, e.g. ``(0, 1)`` or ``(1, 5)``. Supplying it enables the normalized canonical risk in ``GuardrailOutput.score``; when omitted, ``score`` is ``None`` and the raw rubric value is still available in ``extra["rubric_score"]``. |
+| `prompt` | `PromptTemplate | None` | No | `None` | Optional prompt-template override, used as-is (system prompt filling ``{data}`` / ``{pass_criteria}`` / ``{rubric}`` plus the ``input`` / ``input_output`` data wrappers). Defaults to ``None`` — the registry default, or the version named by ``prompt_version``. |
+| `prompt_version` | `str | None` | No | `None` | Registered prompt version to use when ``prompt`` is not given. Defaults to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``. |
 
 Initialize the GLIDER guardrail.
 

--- a/docs/api/guardrails/gpt-oss-safeguard.md
+++ b/docs/api/guardrails/gpt-oss-safeguard.md
@@ -1,6 +1,6 @@
 # GptOssSafeguard
 
-gpt-oss-safeguard — policy-grounded reasoning safety classifier that judges text against a bring-your-own written policy (OpenAI).
+Policy-grounded reasoning safety classifier that judges text against a bring-your-own written policy.
 
 A reasoning LLM that classifies content against a written ``policy`` supplied at
 construction (bring-your-own-taxonomy). The policy becomes the system message; the

--- a/docs/api/guardrails/granite-guardian.md
+++ b/docs/api/guardrails/granite-guardian.md
@@ -1,6 +1,6 @@
 # GraniteGuardian
 
-Granite Guardian — hybrid-thinking safety and judge model covering harm, RAG groundedness, and function-calling risks via bring-your-own-criteria (IBM).
+Hybrid-thinking safety and judge model covering harm, RAG groundedness, and function-calling risks via bring-your-own-criteria.
 
 Granite Guardian is a decoder-LLM safeguard, derived from IBM's Granite models, that
 evaluates whether a given text meets a single user-specified criterion. It runs through

--- a/docs/api/guardrails/harm-guard.md
+++ b/docs/api/guardrails/harm-guard.md
@@ -1,6 +1,6 @@
 # HarmGuard
 
-HarmAug-Guard — binary safety and jailbreak classifier built on DeBERTa-v3-large, scoring a prompt or prompt-response pair.
+Binary safety and jailbreak classifier, scoring a prompt or prompt-response pair.
 
 HarmAug-Guard is a 435M DeBERTa-v3-large classifier distilled from a much larger (7B+)
 teacher safety model using the HarmAug data-augmentation method, which jailbreaks an LLM

--- a/docs/api/guardrails/index.md
+++ b/docs/api/guardrails/index.md
@@ -8,61 +8,67 @@ Query this catalog programmatically with `AnyGuardrail.list_guardrails(...)` and
 
 | Guardrail | Description |
 |-----------|-------------|
-| [Azure Prompt Shields](azure-prompt-shields.md) | Azure AI Prompt Shields — hosted detector for direct (user prompt) and indirect (document-borne) prompt-injection and jailbreak attacks (Microsoft). |
-| [Deepset](deepset.md) | Deepset — binary prompt-injection classifier built on DeBERTa-v3-base (deepset). |
-| [HarmAug-Guard](harm-guard.md) | HarmAug-Guard — binary safety and jailbreak classifier built on DeBERTa-v3-large, scoring a prompt or prompt-response pair. |
-| [Jasper](jasper.md) | Jasper — binary prompt-injection classifiers built on DeBERTa-v3-base and gELECTRA-base (JasperLS). |
-| [Lakera Guard](lakera-guard.md) | Lakera Guard — hosted API for prompt-injection, jailbreak, content-moderation, and PII detection (Lakera). |
-| [Pangolin Guard](pangolin.md) | Pangolin Guard — binary prompt-injection classifier built on ModernBERT (dcarpintero). |
-| [PIGuard](injec-guard.md) | PIGuard — binary prompt-injection classifier built on DeBERTa-v3 and trained to mitigate over-defense (successor to InjecGuard). |
-| [Prompt Guard 2](prompt-guard.md) | Prompt Guard 2 — encoder classifier for prompt-injection and jailbreak detection (Meta). |
-| [ProtectAI](protectai.md) | ProtectAI — binary prompt-injection classifiers built on DeBERTa-v3 and DistilRoBERTa (ProtectAI). |
-| [Sentinel](sentinel.md) | Sentinel — binary prompt-injection classifier built on DeBERTa (Qualifire). |
+| [Azure Prompt Shields](azure-prompt-shields.md) | Hosted detector for direct (user prompt) and indirect (document-borne) prompt-injection and jailbreak attacks. |
+| [Deepset](deepset.md) | Binary prompt-injection classifier. |
+| [HarmAug-Guard](harm-guard.md) | Binary safety and jailbreak classifier, scoring a prompt or prompt-response pair. |
+| [Jasper](jasper.md) | Binary prompt-injection classifiers. |
+| [Lakera Guard](lakera-guard.md) | Hosted API for prompt-injection, jailbreak, content-moderation, and PII detection. |
+| [Pangolin Guard](pangolin.md) | Binary prompt-injection classifier. |
+| [PIGuard](injec-guard.md) | Binary prompt-injection classifier trained to mitigate over-defense. |
+| [Prompt Guard 2](prompt-guard.md) | Encoder classifier for prompt-injection and jailbreak detection. |
+| [ProtectAI](protectai.md) | Binary prompt-injection classifiers. |
+| [Sentinel](sentinel.md) | Binary prompt-injection classifier. |
 
 ## Content Safety
 
 | Guardrail | Description |
 |-----------|-------------|
-| [Alinia](alinia.md) | Alinia — hosted content-moderation and safety-detection API with configurable detection policies (Alinia AI). |
-| [Azure Content Safety](azure-content-safety.md) | Azure AI Content Safety — hosted moderation of text and images across hate, sexual, self-harm, and violence categories with 0-7 severity scores (Microsoft). |
-| [Bedrock Guardrails](bedrock-guardrails.md) | AWS Bedrock Guardrails — hosted, configurable moderation via the ApplyGuardrail API covering content filters, denied topics, PII, word filters, and contextual grounding (Amazon). |
-| [Bielik Guard](bielik-guard.md) | Bielik Guard — Polish multi-label safety classifier (SpeakLeash / Bielik.AI). |
-| [DuoGuard](duo-guard.md) | DuoGuard — multilingual multi-label safety classifier scoring text across 12 harm categories including jailbreak prompts. |
-| [GLiGuard](gli-guard.md) | GLiGuard — schema-driven safety, toxicity, jailbreak, and refusal detector built on GLiNER2 (Fastino). |
-| [gpt-oss-safeguard](gpt-oss-safeguard.md) | gpt-oss-safeguard — policy-grounded reasoning safety classifier that judges text against a bring-your-own written policy (OpenAI). |
-| [Kanana Safeguard](kanana-safeguard.md) | Kanana Safeguard — Korean safety decoder models covering harmful content, legal risk, and prompt attacks (Kakao). |
-| [Llama Guard](llama-guard.md) | Llama Guard — decoder-LLM safety classifier judging prompts and responses against the 14-category MLCommons hazard taxonomy (Meta). |
-| [Nemotron Content Safety](nemotron-content-safety.md) | Nemotron Content Safety — 4B reasoning safety classifier covering a 22-category content-safety taxonomy (NVIDIA). |
-| [OpenAI Moderation](openai-moderation.md) | OpenAI Moderation — hosted moderation API flagging content across 13 harm categories with calibrated scores (OpenAI). |
-| [PolyGuard](poly-guard.md) | PolyGuard — multilingual safety-moderation judge reporting request harm, response harm, and refusal across 17 languages. |
-| [Qwen3Guard](qwen3-guard.md) | Qwen3Guard-Gen — generative safety moderation with three-level severity across 119 languages (Qwen). |
-| [Qwen3Guard-Stream](qwen3-guard-stream.md) | Qwen3Guard-Stream — token-level streaming safety moderation with span output (Qwen). |
-| [ShieldGemma](shield-gemma.md) | ShieldGemma — policy-conditioned safety classifier that judges a prompt against a user-supplied policy via Yes/No token logits (Google). |
-| [watsonx Guardian](watsonx-guardian.md) | watsonx Guardian — hosted text-detection moderation API running configurable Granite Guardian detectors (IBM). |
-| [WildGuard](wild-guard.md) | WildGuard — one-pass safety-moderation judge reporting prompt harm, response harm, and refusal (Allen Institute for AI). |
+| [Alinia](alinia.md) | Hosted content-moderation and safety-detection API with configurable detection policies. |
+| [Azure Content Safety](azure-content-safety.md) | Hosted moderation of text and images across hate, sexual, self-harm, and violence categories with 0-7 severity scores. |
+| [Bedrock Guardrails](bedrock-guardrails.md) | Hosted, configurable moderation covering content filters, denied topics, PII, word filters, and contextual grounding. |
+| [Bielik Guard](bielik-guard.md) | Polish multi-label safety classifier. |
+| [DuoGuard](duo-guard.md) | Multilingual multi-label safety classifier scoring text across 12 harm categories including jailbreak prompts. |
+| [GLiGuard](gli-guard.md) | Schema-driven safety, toxicity, jailbreak, and refusal detector. |
+| [gpt-oss-safeguard](gpt-oss-safeguard.md) | Policy-grounded reasoning safety classifier that judges text against a bring-your-own written policy. |
+| [Kanana Safeguard](kanana-safeguard.md) | Korean safety decoder models covering harmful content, legal risk, and prompt attacks. |
+| [Llama Guard](llama-guard.md) | Decoder-LLM safety classifier judging prompts and responses against the 14-category MLCommons hazard taxonomy. |
+| [Nemotron Content Safety](nemotron-content-safety.md) | Reasoning safety classifier covering a 22-category content-safety taxonomy. |
+| [OpenAI Moderation](openai-moderation.md) | Hosted moderation API flagging content across 13 harm categories with calibrated scores. |
+| [PolyGuard](poly-guard.md) | Multilingual safety-moderation judge reporting request harm, response harm, and refusal across 17 languages. |
+| [Qwen3Guard](qwen3-guard.md) | Generative safety moderation with three-level severity across 119 languages. |
+| [Qwen3Guard-Stream](qwen3-guard-stream.md) | Token-level streaming safety moderation with span output. |
+| [ShieldGemma](shield-gemma.md) | Policy-conditioned safety classifier that judges a prompt against a user-supplied policy via Yes/No token logits. |
+| [watsonx Guardian](watsonx-guardian.md) | Hosted text-detection moderation API running configurable Granite Guardian detectors. |
+| [WildGuard](wild-guard.md) | One-pass safety-moderation judge reporting prompt harm, response harm, and refusal. |
+
+## PII
+
+| Guardrail | Description |
+|-----------|-------------|
+| [GLiNER2 PII](gli-ner-pii.md) | Span-level PII/NER detector emitting character spans and a redacted copy of the text. |
 
 ## Hallucination
 
 | Guardrail | Description |
 |-----------|-------------|
-| [LettuceDetect](lettuce-detect.md) | LettuceDetect — token/span-level RAG hallucination detector built on ModernBERT (KRLabs). |
+| [LettuceDetect](lettuce-detect.md) | Token/span-level RAG hallucination detector. |
 
 ## Off-Topic
 
 | Guardrail | Description |
 |-----------|-------------|
-| [Off-Topic](off-topic.md) | Off-Topic — cross-encoder relevance detector that flags whether an input strays from a comparison text (GovTech Singapore). |
+| [Off-Topic](off-topic.md) | Cross-encoder relevance detector that flags whether an input strays from a comparison text. |
 
 ## General Judge
 
 | Guardrail | Description |
 |-----------|-------------|
-| [AnyLlm](any-llm.md) | AnyLlm — policy-based LLM judge that grades text against a natural-language policy using any LLM provider supported by any-llm. |
-| [CompassJudger](compass-judger.md) | CompassJudger — generalist LLM judge that scores a response against user-defined criteria and rubric on a 1-10 scale (OpenCompass). |
-| [DynaGuard](dyna-guard.md) | DynaGuard — dynamic guardian model evaluating conversation compliance with user-defined policies. |
-| [Flow Judge](flowjudge.md) | Flow Judge — local LLM judge scoring text against user-defined criteria, metrics, and rubrics via the flow-judge library (Flow AI). |
-| [GLIDER](glider.md) | GLIDER — prompt-based LLM judge that grades text against user-supplied pass criteria and rubric, returning reasoning and highlighted phrases (Patronus AI). |
-| [Granite Guardian](granite-guardian.md) | Granite Guardian — hybrid-thinking safety and judge model covering harm, RAG groundedness, and function-calling risks via bring-your-own-criteria (IBM). |
-| [Patronus](patronus.md) | Patronus — hosted evaluation API running configurable evaluators for hallucination, toxicity, PII, prompt injection, and custom judging (Patronus AI). |
-| [Prometheus](prometheus.md) | Prometheus — open rubric-based LLM judge grading a response on a user-defined 1-5 rubric (KAIST / prometheus-eval). |
-| [Selene 1 Mini](selene.md) | Selene 1 Mini — general-purpose LLM judge grading a response against a user-defined 1-5 rubric (Atla). |
+| [AnyLlm](any-llm.md) | Policy-based LLM judge that grades text against a natural-language policy using an LLM provider. |
+| [CompassJudger](compass-judger.md) | Generalist LLM judge that scores a response against user-defined criteria and rubric on a 1-10 scale. |
+| [DynaGuard](dyna-guard.md) | Dynamic guardian model evaluating conversation compliance with user-defined policies. |
+| [Flow Judge](flowjudge.md) | Local LLM judge scoring text against user-defined criteria, metrics, and rubrics. |
+| [GLIDER](glider.md) | Prompt-based LLM judge that grades text against user-supplied pass criteria and rubric, returning reasoning and highlighted phrases. |
+| [Granite Guardian](granite-guardian.md) | Hybrid-thinking safety and judge model covering harm, RAG groundedness, and function-calling risks via bring-your-own-criteria. |
+| [Patronus](patronus.md) | Hosted evaluation API running configurable evaluators for hallucination, toxicity, PII, prompt injection, and custom judging. |
+| [Prometheus](prometheus.md) | Open rubric-based LLM judge grading a response on a user-defined 1-5 rubric. |
+| [Selene 1 Mini](selene.md) | General-purpose LLM judge grading a response against a user-defined 1-5 rubric. |

--- a/docs/api/guardrails/injec-guard.md
+++ b/docs/api/guardrails/injec-guard.md
@@ -1,6 +1,6 @@
 # InjecGuard
 
-PIGuard — binary prompt-injection classifier built on DeBERTa-v3 and trained to mitigate over-defense (successor to InjecGuard).
+Binary prompt-injection classifier trained to mitigate over-defense.
 
 Runs PIGuard's DeBERTa-v3 encoder classifier over a single user prompt and reports whether the
 text is a prompt-injection attempt. The model is a two-class sequence classifier whose unsafe

--- a/docs/api/guardrails/jasper.md
+++ b/docs/api/guardrails/jasper.md
@@ -1,6 +1,6 @@
 # Jasper
 
-Jasper — binary prompt-injection classifiers built on DeBERTa-v3-base and gELECTRA-base (JasperLS).
+Binary prompt-injection classifiers.
 
 Runs one of JasperLS's encoder classifiers over a single user prompt and reports whether the
 text is a prompt-injection attempt. Each model is a two-class sequence classifier whose unsafe

--- a/docs/api/guardrails/kanana-safeguard.md
+++ b/docs/api/guardrails/kanana-safeguard.md
@@ -1,6 +1,6 @@
 # KananaSafeguard
 
-Kanana Safeguard — Korean safety decoder models covering harmful content, legal risk, and prompt attacks (Kakao).
+Korean safety decoder models covering harmful content, legal risk, and prompt attacks.
 
 Decoder LLMs, trained primarily for Korean text, that emit a single verdict token:
 ``<SAFE>`` or an ``<UNSAFE-*>`` code. Three variants cover different taxonomies:

--- a/docs/api/guardrails/lakera-guard.md
+++ b/docs/api/guardrails/lakera-guard.md
@@ -1,6 +1,6 @@
 # LakeraGuard
 
-Lakera Guard — hosted API for prompt-injection, jailbreak, content-moderation, and PII detection (Lakera).
+Hosted API for prompt-injection, jailbreak, content-moderation, and PII detection.
 
 Lakera Guard exposes a single ``/v2/guard`` endpoint that returns whether a message (or message list)
 was flagged. ``validate(content)`` accepts either a plain string (wrapped as a single user-role

--- a/docs/api/guardrails/lettuce-detect.md
+++ b/docs/api/guardrails/lettuce-detect.md
@@ -1,6 +1,6 @@
 # LettuceDetect
 
-LettuceDetect — token/span-level RAG hallucination detector built on ModernBERT (KRLabs).
+Token/span-level RAG hallucination detector.
 
 Wraps the ``lettucedetect`` library to flag spans of an answer that are not supported
 by the provided context. Token classification over the (context, question, answer)

--- a/docs/api/guardrails/llama-guard.md
+++ b/docs/api/guardrails/llama-guard.md
@@ -1,6 +1,6 @@
 # LlamaGuard
 
-Llama Guard — decoder-LLM safety classifier judging prompts and responses against the 14-category MLCommons hazard taxonomy (Meta).
+Decoder-LLM safety classifier judging prompts and responses against the 14-category MLCommons hazard taxonomy.
 
 Llama Guard is Meta's instruction-tuned safety model. Each call wraps a user prompt (and,
 optionally, an assistant response) in the model's moderation template listing the 14 MLCommons

--- a/docs/api/guardrails/nemotron-content-safety.md
+++ b/docs/api/guardrails/nemotron-content-safety.md
@@ -1,6 +1,6 @@
 # NemotronContentSafety
 
-Nemotron Content Safety — 4B reasoning safety classifier covering a 22-category content-safety taxonomy (NVIDIA).
+Reasoning safety classifier covering a 22-category content-safety taxonomy.
 
 Decoder LLM (Gemma-3-4B base) that classifies a user prompt and an optional assistant response
 against NVIDIA's 22-category content-safety taxonomy (``S1`` Violence ... ``S22``

--- a/docs/api/guardrails/off-topic.md
+++ b/docs/api/guardrails/off-topic.md
@@ -1,6 +1,6 @@
 # OffTopic
 
-Off-Topic — cross-encoder relevance detector that flags whether an input strays from a comparison text (GovTech Singapore).
+Cross-encoder relevance detector that flags whether an input strays from a comparison text.
 
 A dispatcher over GovTech Singapore's two open off-topic detection models. Given an
 ``input_text`` and a ``comparison_text`` (typically the system prompt or the app's

--- a/docs/api/guardrails/openai-moderation.md
+++ b/docs/api/guardrails/openai-moderation.md
@@ -1,6 +1,6 @@
 # OpenaiModeration
 
-OpenAI Moderation — hosted moderation API flagging content across 13 harm categories with calibrated scores (OpenAI).
+Hosted moderation API flagging content across 13 harm categories with calibrated scores.
 
 Wraps OpenAI's hosted moderation classifier (default model:
 ``omni-moderation-latest``) to flag content across 13 harm

--- a/docs/api/guardrails/pangolin.md
+++ b/docs/api/guardrails/pangolin.md
@@ -1,13 +1,10 @@
 # Pangolin
 
-Pangolin Guard — binary prompt-injection classifier built on ModernBERT (dcarpintero).
+Binary prompt-injection classifier.
 
-Runs one of dcarpintero's ModernBERT encoder classifiers over a single user prompt and reports
-whether the text is a prompt-injection / jailbreak attempt. Each model is a two-class sequence
-classifier whose unsafe class is labeled ``"unsafe"``; the guardrail treats that class as the
-risky one. The default ``pangolin-guard-base`` is ModernBERT-base; ``pangolin-guard-large`` is a
-higher-accuracy ModernBERT-large drop-in with an 8192-token context and the same ``"unsafe"``
-label.
+Runs dcarpintero's ModernBERT-base encoder classifier over a single user prompt and reports
+whether the text is a prompt-injection / jailbreak attempt. It is a two-class sequence classifier
+whose unsafe class is labeled ``"unsafe"``; the guardrail treats that class as the risky one.
 
 Expected input: prompt-only text. ``validate(input_text)`` accepts a single string, or a
 ``list[str]`` to classify a batch in one call; there is no prompt+response or chat-message mode.
@@ -23,20 +20,17 @@ Verdict mapping onto ``GuardrailOutput``:
 
 For more information, see:
 
-- [Pangolin Guard base](https://huggingface.co/dcarpintero/pangolin-guard-base) (default) — ModernBERT-base.
-- [Pangolin Guard large](https://huggingface.co/dcarpintero/pangolin-guard-large) — ModernBERT-large;
-  higher accuracy, 8192-token context. Same ``"unsafe"`` label, so it is a drop-in alternative.
+- [Pangolin Guard base](https://huggingface.co/dcarpintero/pangolin-guard-base) — ModernBERT-base.
 
 ## Supported Models
 
 - `dcarpintero/pangolin-guard-base`
-- `dcarpintero/pangolin-guard-large`
 
 ## Constructor
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `model_id` | `str | None` | No | `None` | Optional HuggingFace model ID. Must be one of ``SUPPORTED_MODELS``; defaults to ``dcarpintero/pangolin-guard-base`` (ModernBERT-base). Pass ``"dcarpintero/pangolin-guard-large"`` for the higher-accuracy ModernBERT-large variant with an 8192-token context. Both share the same ``"unsafe"`` label. |
+| `model_id` | `str | None` | No | `None` | Optional HuggingFace model ID. Must be one of ``SUPPORTED_MODELS``; defaults to ``dcarpintero/pangolin-guard-base`` (ModernBERT-base). |
 | `provider` | `Provider[dict[str, Any], dict[str, Any]] | None` | No | `None` | Execution backend that loads the model and runs inference. Defaults to a ``HuggingFaceProvider`` targeting ``AutoModelForSequenceClassification``. Supply your own to control device, dtype, or ``cache_dir``, or to run against a different backend. |
 
 Initialize the Pangolin Guard guardrail.

--- a/docs/api/guardrails/patronus.md
+++ b/docs/api/guardrails/patronus.md
@@ -1,6 +1,6 @@
 # Patronus
 
-Patronus — hosted evaluation API running configurable evaluators for hallucination, toxicity, PII, prompt injection, and custom judging (Patronus AI).
+Hosted evaluation API running configurable evaluators for hallucination, toxicity, PII, prompt injection, and custom judging.
 
 This is the hosted, pay-per-use counterpart to the locally-run
 :class:`~any_guardrail.guardrails.glider.glider.Glider` (GLIDER) judge and the

--- a/docs/api/guardrails/poly-guard.md
+++ b/docs/api/guardrails/poly-guard.md
@@ -1,6 +1,6 @@
 # PolyGuard
 
-PolyGuard — multilingual safety-moderation judge reporting request harm, response harm, and refusal across 17 languages.
+Multilingual safety-moderation judge reporting request harm, response harm, and refusal across 17 languages.
 
 Generative classifier (fine-tuned Ministral / Qwen decoder LLMs) that, given a human request
 and an optional assistant response, reports three boolean signals — whether the request is
@@ -43,6 +43,8 @@ For more information, see the model cards:
 |-----------|------|----------|---------|-------------|
 | `model_id` | `str | None` | No | `None` | Optional HuggingFace model ID; must be one of ``SUPPORTED_MODELS``. Defaults to ``ToxicityPrompts/PolyGuard-Ministral``; ``ToxicityPrompts/PolyGuard-Qwen`` and ``ToxicityPrompts/PolyGuard-Qwen-Smol`` are the Qwen-based alternatives. |
 | `provider` | `Provider[dict[str, Any], dict[str, Any]] | None` | No | `None` | Optional pre-configured provider. When ``None``, a ``HuggingFaceProvider`` is built targeting a causal LM (``AutoModelForCausalLM`` + ``AutoTokenizer``). A supplied ``HuggingFaceProvider`` is corrected to those classes at load time; any other provider is used as-is. |
+| `prompt` | `PromptTemplate | None` | No | `None` | Optional prompt-template override, used as-is (system prompt plus a user template filling ``{prompt}`` / ``{response}``). Defaults to ``None`` — the registry default, or the version named by ``prompt_version``. |
+| `prompt_version` | `str | None` | No | `None` | Registered prompt version to use when ``prompt`` is not given. Defaults to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``. |
 
 Initialize the PolyGuard guardrail.
 

--- a/docs/api/guardrails/prometheus.md
+++ b/docs/api/guardrails/prometheus.md
@@ -1,6 +1,6 @@
 # Prometheus
 
-Prometheus — open rubric-based LLM judge grading a response on a user-defined 1-5 rubric (KAIST / prometheus-eval).
+Open rubric-based LLM judge grading a response on a user-defined 1-5 rubric.
 
 Prometheus is an open-source decoder LLM specialized in evaluating other models'
 outputs. This guardrail drives it in **absolute grading** mode: each call wraps the
@@ -53,6 +53,8 @@ For more information, see:
 | `higher_is_better` | `bool` | No | `True` | Whether higher rubric scores mean better responses. Set ``False`` for rubrics where a higher number is worse (e.g. a severity scale). Defaults to ``True``. |
 | `model_id` | `str | None` | No | `None` | Optional HuggingFace model ID; must be one of ``SUPPORTED_MODELS``. Defaults to ``prometheus-eval/prometheus-7b-v2.0``. |
 | `provider` | `Provider[dict[str, Any], dict[str, Any]] | None` | No | `None` | Optional pre-configured provider. When ``None``, a ``HuggingFaceProvider`` is built targeting ``AutoModelForCausalLM`` / ``AutoTokenizer`` (transformers is imported lazily here). Pass a ``LlamafileProvider`` to run a GGUF build without the huggingface extra. |
+| `prompt` | `PromptTemplate | None` | No | `None` | Optional prompt-template override, used as-is (must fill ``{instruction}`` / ``{response}`` / ``{reference_answer}`` / ``{rubric}``). Defaults to ``None`` — the registry default, or the version named by ``prompt_version``. |
+| `prompt_version` | `str | None` | No | `None` | Registered prompt version to use when ``prompt`` is not given. Defaults to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``. |
 
 Initialize the Prometheus guardrail.
 

--- a/docs/api/guardrails/prompt-guard.md
+++ b/docs/api/guardrails/prompt-guard.md
@@ -1,6 +1,6 @@
 # PromptGuard
 
-Prompt Guard 2 — encoder classifier for prompt-injection and jailbreak detection (Meta).
+Encoder classifier for prompt-injection and jailbreak detection.
 
 Binary encoder classifier (mDeBERTa / DeBERTa) that labels a single prompt string
 ``benign`` (index 0) or ``malicious`` (index 1, i.e. a prompt-injection or jailbreak

--- a/docs/api/guardrails/protectai.md
+++ b/docs/api/guardrails/protectai.md
@@ -1,6 +1,6 @@
 # Protectai
 
-ProtectAI — binary prompt-injection classifiers built on DeBERTa-v3 and DistilRoBERTa (ProtectAI).
+Binary prompt-injection classifiers.
 
 Runs one of ProtectAI's encoder classifiers over a single user prompt and reports whether the
 text is a prompt-injection / jailbreak attempt. Each model is a two-class sequence classifier

--- a/docs/api/guardrails/qwen3-guard-stream.md
+++ b/docs/api/guardrails/qwen3-guard-stream.md
@@ -1,6 +1,6 @@
 # Qwen3GuardStream
 
-Qwen3Guard-Stream — token-level streaming safety moderation with span output (Qwen).
+Token-level streaming safety moderation with span output.
 
 Classifier heads on a Qwen3 backbone (loaded as remote code) that judge the user
 prompt as a whole and every assistant response token individually, each with a

--- a/docs/api/guardrails/qwen3-guard.md
+++ b/docs/api/guardrails/qwen3-guard.md
@@ -1,6 +1,6 @@
 # Qwen3Guard
 
-Qwen3Guard-Gen — generative safety moderation with three-level severity across 119 languages (Qwen).
+Generative safety moderation with three-level severity across 119 languages.
 
 Decoder LLM (Apache-2.0) whose chat template embeds the safety-classifier
 instruction: the user prompt alone triggers prompt moderation; supplying an

--- a/docs/api/guardrails/selene.md
+++ b/docs/api/guardrails/selene.md
@@ -1,6 +1,6 @@
 # Selene
 
-Selene 1 Mini — general-purpose LLM judge grading a response against a user-defined 1-5 rubric (Atla).
+General-purpose LLM judge grading a response against a user-defined 1-5 rubric.
 
 Selene 1 Mini is an 8B evaluator LLM (fine-tuned from Llama 3.1 8B) specialized in
 scoring model outputs. This guardrail drives it in single-rubric absolute-grading mode:
@@ -45,6 +45,8 @@ For more information, see:
 | `higher_is_better` | `bool` | No | `True` | Whether higher rubric scores mean better responses. Set ``False`` for rubrics where a higher number is worse. Defaults to ``True``. |
 | `model_id` | `str | None` | No | `None` | Optional HuggingFace model ID; must be one of ``SUPPORTED_MODELS``. Defaults to ``AtlaAI/Selene-1-Mini-Llama-3.1-8B``. |
 | `provider` | `Provider[dict[str, Any], dict[str, Any]] | None` | No | `None` | Optional pre-configured provider. When ``None``, a ``HuggingFaceProvider`` is built targeting ``AutoModelForCausalLM`` / ``AutoTokenizer`` (transformers is imported lazily here). Pass a ``LlamafileProvider`` to run a GGUF build without the huggingface extra. |
+| `prompt` | `PromptTemplate | None` | No | `None` | Optional prompt-template override, used as-is (must fill ``{instruction}`` / ``{response}`` / ``{rubric}``). Defaults to ``None`` — the registry default, or the version named by ``prompt_version``. |
+| `prompt_version` | `str | None` | No | `None` | Registered prompt version to use when ``prompt`` is not given. Defaults to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``. |
 
 Initialize the Selene guardrail.
 

--- a/docs/api/guardrails/sentinel.md
+++ b/docs/api/guardrails/sentinel.md
@@ -1,6 +1,6 @@
 # Sentinel
 
-Sentinel — binary prompt-injection classifier built on DeBERTa (Qualifire).
+Binary prompt-injection classifier.
 
 Runs Qualifire's DeBERTa-based encoder classifier over a single user prompt and reports whether
 the text is a prompt-injection / jailbreak attempt. The model is a two-class sequence classifier

--- a/docs/api/guardrails/shield-gemma.md
+++ b/docs/api/guardrails/shield-gemma.md
@@ -1,6 +1,6 @@
 # ShieldGemma
 
-ShieldGemma — policy-conditioned safety classifier that judges a prompt against a user-supplied policy via Yes/No token logits (Google).
+Policy-conditioned safety classifier that judges a prompt against a user-supplied policy via Yes/No token logits.
 
 ShieldGemma is Google's Gemma-2-based content-safety classifier. Rather than a fixed taxonomy,
 it is conditioned at construction on a free-text ``policy`` (a safety principle). Each call
@@ -44,6 +44,8 @@ For more information, see:
 | `threshold` | `float` | No | `0.5` | Decision threshold on the ``Yes`` (violation) probability. ``valid`` is ``score < threshold``; raise it to flag only higher-confidence violations, lower it to be stricter. Defaults to ``0.5``. |
 | `model_id` | `str | None` | No | `None` | Optional HuggingFace model ID; must be one of ``SUPPORTED_MODELS``. Defaults to ``google/shieldgemma-2b``. |
 | `provider` | `Provider[dict[str, Any], dict[str, Any]] | None` | No | `None` | Optional pre-configured provider. When ``None``, a ``HuggingFaceProvider`` is built targeting a causal LM (``AutoModelForCausalLM`` + ``AutoTokenizer``). A supplied ``HuggingFaceProvider`` is corrected to those classes at load time so the Yes/No logit head is available; any other provider is used as-is. |
+| `prompt` | `PromptTemplate | None` | No | `None` | Optional prompt-template override, used as-is (must fill ``{user_prompt}`` and ``{safety_policy}``). Defaults to ``None`` — the registry default, or the version named by ``prompt_version``. |
+| `prompt_version` | `str | None` | No | `None` | Registered prompt version to use when ``prompt`` is not given. Defaults to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``. |
 
 Initialize the ShieldGemma guardrail.
 

--- a/docs/api/guardrails/watsonx-guardian.md
+++ b/docs/api/guardrails/watsonx-guardian.md
@@ -1,6 +1,6 @@
 # WatsonxGuardian
 
-watsonx Guardian — hosted text-detection moderation API running configurable Granite Guardian detectors (IBM).
+Hosted text-detection moderation API running configurable Granite Guardian detectors.
 
 This is the hosted, pay-per-use counterpart to the locally-run
 :class:`~any_guardrail.guardrails.granite_guardian.granite_guardian.GraniteGuardian`

--- a/docs/api/guardrails/wild-guard.md
+++ b/docs/api/guardrails/wild-guard.md
@@ -1,6 +1,6 @@
 # WildGuard
 
-WildGuard — one-pass safety-moderation judge reporting prompt harm, response harm, and refusal (Allen Institute for AI).
+One-pass safety-moderation judge reporting prompt harm, response harm, and refusal.
 
 WildGuard is a generative safety classifier that evaluates a prompt-response
 interaction in a single forward pass, reporting three signals: (1) whether the
@@ -47,6 +47,8 @@ For more information, see:
 |-----------|------|----------|---------|-------------|
 | `model_id` | `str | None` | No | `None` | Optional HuggingFace model ID. Must be one of ``SUPPORTED_MODELS``; defaults to ``allenai/wildguard``. |
 | `provider` | `Provider[dict[str, Any], dict[str, Any]] | None` | No | `None` | Optional pre-configured provider. Defaults to a ``HuggingFaceProvider`` loading the model as a causal LM. When a ``HuggingFaceProvider`` is supplied, it is loaded with ``model_class=AutoModelForCausalLM`` / ``tokenizer_class=AutoTokenizer`` so its default sequence-classification loader is corrected. |
+| `prompt` | `PromptTemplate | None` | No | `None` | Optional prompt-template override, used as-is (must fill ``{prompt}`` / ``{response}``). Defaults to ``None`` — the registry default, or the version named by ``prompt_version``. |
+| `prompt_version` | `str | None` | No | `None` | Registered prompt version to use when ``prompt`` is not given. Defaults to ``None`` (the default version). See ``AnyGuardrail.list_prompt_versions``. |
 
 Initialize the WildGuard guardrail.
 

--- a/schemas/guardrail_parameters.json
+++ b/schemas/guardrail_parameters.json
@@ -1546,11 +1546,10 @@
     "parameters": [
       {
         "choices": [
-          "dcarpintero/pangolin-guard-base",
-          "dcarpintero/pangolin-guard-large"
+          "dcarpintero/pangolin-guard-base"
         ],
         "default": null,
-        "description": "Optional HuggingFace model ID. Must be one of ``SUPPORTED_MODELS``; defaults to ``dcarpintero/pangolin-guard-base`` (ModernBERT-base). Pass ``\"dcarpintero/pangolin-guard-large\"`` for the higher-accuracy ModernBERT-large variant with an 8192-token context. Both share the same ``\"unsafe\"`` label.",
+        "description": "Optional HuggingFace model ID. Must be one of ``SUPPORTED_MODELS``; defaults to ``dcarpintero/pangolin-guard-base`` (ModernBERT-base).",
         "effectively_required": false,
         "env_var": null,
         "name": "model_id",

--- a/src/any_guardrail/_parameter_data.py
+++ b/src/any_guardrail/_parameter_data.py
@@ -1478,11 +1478,10 @@ _PARAMETER_DATA_JSON = r"""
   "pangolin": [
     {
       "choices": [
-        "dcarpintero/pangolin-guard-base",
-        "dcarpintero/pangolin-guard-large"
+        "dcarpintero/pangolin-guard-base"
       ],
       "default": null,
-      "description": "Optional HuggingFace model ID. Must be one of ``SUPPORTED_MODELS``; defaults to ``dcarpintero/pangolin-guard-base`` (ModernBERT-base). Pass ``\"dcarpintero/pangolin-guard-large\"`` for the higher-accuracy ModernBERT-large variant with an 8192-token context. Both share the same ``\"unsafe\"`` label.",
+      "description": "Optional HuggingFace model ID. Must be one of ``SUPPORTED_MODELS``; defaults to ``dcarpintero/pangolin-guard-base`` (ModernBERT-base).",
       "effectively_required": false,
       "env_var": null,
       "name": "model_id",

--- a/src/any_guardrail/api.py
+++ b/src/any_guardrail/api.py
@@ -280,14 +280,19 @@ class AnyGuardrail:
 
         Guardrails whose optional extra isn't installed are skipped rather than
         raising, since this is a discovery API and the natural use is "what can I
-        run here?" on a partial install.
+        run here?" on a partial install. Every guardrail module that gates an
+        optional SDK re-raises the failed import as ``raise ImportError(msg) from
+        e``, so only an ``ImportError`` with a chained cause is treated as a
+        missing-extra signal; an uncaused ``ImportError`` (e.g. an unresolvable
+        module path or class name) is a real bug and propagates.
         """
         model_ids = {}
         for guardrail_name in cls.get_supported_guardrails():
             try:
                 model_ids[guardrail_name.value] = cls.get_supported_model(guardrail_name)
-            except ImportError:
-                continue
+            except ImportError as e:
+                if e.__cause__ is None:
+                    raise
         return model_ids
 
     @classmethod

--- a/src/any_guardrail/api.py
+++ b/src/any_guardrail/api.py
@@ -276,10 +276,18 @@ class AnyGuardrail:
 
     @classmethod
     def get_all_supported_models(cls) -> dict[str, list[str]]:
-        """Get all model IDs supported by all guardrails."""
+        """Get all model IDs supported by all guardrails.
+
+        Guardrails whose optional extra isn't installed are skipped rather than
+        raising, since this is a discovery API and the natural use is "what can I
+        run here?" on a partial install.
+        """
         model_ids = {}
         for guardrail_name in cls.get_supported_guardrails():
-            model_ids[guardrail_name.value] = cls.get_supported_model(guardrail_name)
+            try:
+                model_ids[guardrail_name.value] = cls.get_supported_model(guardrail_name)
+            except ImportError:
+                continue
         return model_ids
 
     @classmethod

--- a/src/any_guardrail/guardrails/pangolin/pangolin.py
+++ b/src/any_guardrail/guardrails/pangolin/pangolin.py
@@ -14,12 +14,9 @@ PANGOLIN_INJECTION_LABEL = "unsafe"
 class Pangolin(StandardGuardrail):
     """Binary prompt-injection classifier.
 
-    Runs one of dcarpintero's ModernBERT encoder classifiers over a single user prompt and reports
-    whether the text is a prompt-injection / jailbreak attempt. Each model is a two-class sequence
-    classifier whose unsafe class is labeled ``"unsafe"``; the guardrail treats that class as the
-    risky one. The default ``pangolin-guard-base`` is ModernBERT-base; ``pangolin-guard-large`` is a
-    higher-accuracy ModernBERT-large drop-in with an 8192-token context and the same ``"unsafe"``
-    label.
+    Runs dcarpintero's ModernBERT-base encoder classifier over a single user prompt and reports
+    whether the text is a prompt-injection / jailbreak attempt. It is a two-class sequence classifier
+    whose unsafe class is labeled ``"unsafe"``; the guardrail treats that class as the risky one.
 
     Expected input: prompt-only text. ``validate(input_text)`` accepts a single string, or a
     ``list[str]`` to classify a batch in one call; there is no prompt+response or chat-message mode.
@@ -35,13 +32,11 @@ class Pangolin(StandardGuardrail):
 
     For more information, see:
 
-    - [Pangolin Guard base](https://huggingface.co/dcarpintero/pangolin-guard-base) (default) — ModernBERT-base.
-    - [Pangolin Guard large](https://huggingface.co/dcarpintero/pangolin-guard-large) — ModernBERT-large;
-      higher accuracy, 8192-token context. Same ``"unsafe"`` label, so it is a drop-in alternative.
+    - [Pangolin Guard base](https://huggingface.co/dcarpintero/pangolin-guard-base) — ModernBERT-base.
 
     """
 
-    SUPPORTED_MODELS: ClassVar = ["dcarpintero/pangolin-guard-base", "dcarpintero/pangolin-guard-large"]
+    SUPPORTED_MODELS: ClassVar = ["dcarpintero/pangolin-guard-base"]
 
     METADATA: ClassVar[GuardrailMetadata] = GUARDRAIL_METADATA[GuardrailName.PANGOLIN]
 
@@ -50,9 +45,7 @@ class Pangolin(StandardGuardrail):
 
         Args:
             model_id: Optional HuggingFace model ID. Must be one of ``SUPPORTED_MODELS``; defaults
-                to ``dcarpintero/pangolin-guard-base`` (ModernBERT-base). Pass
-                ``"dcarpintero/pangolin-guard-large"`` for the higher-accuracy ModernBERT-large
-                variant with an 8192-token context. Both share the same ``"unsafe"`` label.
+                to ``dcarpintero/pangolin-guard-base`` (ModernBERT-base).
             provider: Execution backend that loads the model and runs inference. Defaults to a
                 ``HuggingFaceProvider`` targeting ``AutoModelForSequenceClassification``. Supply your
                 own to control device, dtype, or ``cache_dir``, or to run against a different backend.

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -172,13 +172,18 @@ def test_model_load() -> None:
 
 
 def test_get_all_supported_models_skips_guardrails_with_missing_extras() -> None:
-    """A guardrail whose optional extra isn't installed shouldn't break the aggregate query."""
+    """A guardrail whose optional extra isn't installed shouldn't break the aggregate query.
+
+    Mirrors the real failure shape: every guardrail module that gates an optional
+    SDK does ``raise ImportError(msg) from e``, chaining the original
+    ModuleNotFoundError as the cause.
+    """
     real_get_guardrail_class = AnyGuardrail._get_guardrail_class
 
     def flaky_get_guardrail_class(guardrail_name: GuardrailName) -> type[Guardrail]:
         if guardrail_name == GuardrailName.AZURE_CONTENT_SAFETY:
             msg = "azure-ai-contentsafety package is not installed"
-            raise ImportError(msg)
+            raise ImportError(msg) from ModuleNotFoundError(name="azure.ai.contentsafety")
         return real_get_guardrail_class(guardrail_name)
 
     with patch.object(AnyGuardrail, "_get_guardrail_class", staticmethod(flaky_get_guardrail_class)):
@@ -187,6 +192,25 @@ def test_get_all_supported_models_skips_guardrails_with_missing_extras() -> None
     assert GuardrailName.AZURE_CONTENT_SAFETY.value not in model_ids
     assert GuardrailName.LLAMA_GUARD.value in model_ids
     assert len(model_ids) == len(GuardrailName) - 1
+
+
+def test_get_all_supported_models_reraises_uncaused_import_error() -> None:
+    """An ImportError with no chained cause is a real bug (bad module path, unresolvable
+    class), not a missing extra, and must propagate rather than being silently skipped.
+    """
+    real_get_guardrail_class = AnyGuardrail._get_guardrail_class
+
+    def broken_get_guardrail_class(guardrail_name: GuardrailName) -> type[Guardrail]:
+        if guardrail_name == GuardrailName.AZURE_CONTENT_SAFETY:
+            msg = "Could not resolve guardrail class for 'azure_content_safety'"
+            raise ImportError(msg)
+        return real_get_guardrail_class(guardrail_name)
+
+    with (
+        patch.object(AnyGuardrail, "_get_guardrail_class", staticmethod(broken_get_guardrail_class)),
+        pytest.raises(ImportError, match="Could not resolve guardrail class"),
+    ):
+        AnyGuardrail.get_all_supported_models()
 
 
 def test_post_processing_implementation() -> None:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -171,6 +171,24 @@ def test_model_load() -> None:
                 assert hasattr(guardrail, "provider")
 
 
+def test_get_all_supported_models_skips_guardrails_with_missing_extras() -> None:
+    """A guardrail whose optional extra isn't installed shouldn't break the aggregate query."""
+    real_get_supported_model = AnyGuardrail.get_supported_model.__func__
+
+    def flaky_get_supported_model(cls: type[AnyGuardrail], guardrail_name: GuardrailName) -> list[str]:
+        if guardrail_name == GuardrailName.AZURE_CONTENT_SAFETY:
+            msg = "azure-ai-contentsafety package is not installed"
+            raise ImportError(msg)
+        return real_get_supported_model(cls, guardrail_name)
+
+    with patch.object(AnyGuardrail, "get_supported_model", classmethod(flaky_get_supported_model)):
+        model_ids = AnyGuardrail.get_all_supported_models()
+
+    assert GuardrailName.AZURE_CONTENT_SAFETY.value not in model_ids
+    assert GuardrailName.LLAMA_GUARD.value in model_ids
+    assert len(model_ids) == len(GuardrailName) - 1
+
+
 def test_post_processing_implementation() -> None:
     """Test that all ThreeStageGuardrail subclasses with a provider implement _post_processing."""
     for guardrail_name in GuardrailName:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -173,15 +173,15 @@ def test_model_load() -> None:
 
 def test_get_all_supported_models_skips_guardrails_with_missing_extras() -> None:
     """A guardrail whose optional extra isn't installed shouldn't break the aggregate query."""
-    real_get_supported_model = AnyGuardrail.get_supported_model.__func__
+    real_get_guardrail_class = AnyGuardrail._get_guardrail_class
 
-    def flaky_get_supported_model(cls: type[AnyGuardrail], guardrail_name: GuardrailName) -> list[str]:
+    def flaky_get_guardrail_class(guardrail_name: GuardrailName) -> type[Guardrail]:
         if guardrail_name == GuardrailName.AZURE_CONTENT_SAFETY:
             msg = "azure-ai-contentsafety package is not installed"
             raise ImportError(msg)
-        return real_get_supported_model(cls, guardrail_name)
+        return real_get_guardrail_class(guardrail_name)
 
-    with patch.object(AnyGuardrail, "get_supported_model", classmethod(flaky_get_supported_model)):
+    with patch.object(AnyGuardrail, "_get_guardrail_class", staticmethod(flaky_get_guardrail_class)):
         model_ids = AnyGuardrail.get_all_supported_models()
 
     assert GuardrailName.AZURE_CONTENT_SAFETY.value not in model_ids


### PR DESCRIPTION
## Summary
- Ships an empty `py.typed` marker so downstream `mypy --strict` consumers stop needing an `ignore_missing_imports` override (#223). Packaging config for this was already in place; the file was just never created.
- Regenerates `docs/api/guardrails/*.md`, which had drifted from the current `GUARDRAIL_METADATA` descriptions/docstrings since a past docstring-simplification pass never re-ran `scripts/generate_api_docs.py`. No source changes.
- Drops `dcarpintero/pangolin-guard-large` from `Pangolin.SUPPORTED_MODELS` (#228) — it ships no usable tokenizer files and fails to load on both transformers 4.x and 5.x, so anything enumerating variants programmatically selects a model that can't run.
- Makes `AnyGuardrail.get_all_supported_models()` skip guardrails whose optional extra isn't installed instead of raising `ImportError` for the whole aggregate (#229) — it's a discovery API, so a single missing extra (e.g. `azure-content-safety`) shouldn't break "what can I run here?" for everything else.

## Test plan
- [x] `pytest -v tests/unit` (1086 passed)
- [x] `pre-commit run --all-files` (all hooks pass, including the generated-schema `--check` hooks)
- [x] New regression test for `get_all_supported_models` skipping a guardrail with a simulated missing extra
- [x] Confirmed `py.typed` is picked up by the existing `[tool.setuptools.package-data]` config

Closes #223, #228, #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)