### PR TITLE
fix: drop bitsandbytes from the flowjudge extra (#224)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ bedrock = [
 # guardrail in the process — even though flow-judge's Hf backend never actually
 # uses bitsandbytes (it's only relevant for quantized loading, which isn't wired
 # up there). Depend on flow-judge without the [hf] extra and declare its real
-# runtime needs (transformers, torch, accelerate) ourselves, omitting
+# runtime needs (transformers, torch, accelerate, huggingface-hub — the Hf
+# backend calls huggingface_hub.snapshot_download directly) ourselves, omitting
 # bitsandbytes. If you need quantized loading, install bitsandbytes yourself.
 # See https://github.com/mozilla-ai/any-guardrail/issues/224.
 flowjudge = [
@@ -39,6 +40,7 @@ flowjudge = [
   "transformers>=4.53.2",
   "torch>=2.7.1",
   "accelerate>=0.34.2",
+  "huggingface-hub>=0.33.4",
 ]
 
 # Token-level RAG hallucination detection (LettuceDetect guardrail).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,19 @@ bedrock = [
     "boto3>=1.39.0"
 ]
 
+# flow-judge[hf] pins bitsandbytes<=0.42.0 (Jan 2024), which aborts at import on
+# CUDA>=12 and poisons transformers' bitsandbytes integration for every other
+# guardrail in the process — even though flow-judge's Hf backend never actually
+# uses bitsandbytes (it's only relevant for quantized loading, which isn't wired
+# up there). Depend on flow-judge without the [hf] extra and declare its real
+# runtime needs (transformers, torch, accelerate) ourselves, omitting
+# bitsandbytes. If you need quantized loading, install bitsandbytes yourself.
+# See https://github.com/mozilla-ai/any-guardrail/issues/224.
 flowjudge = [
-  "flow-judge[hf]>=0.1.2"
+  "flow-judge>=0.1.2",
+  "transformers>=4.53.2",
+  "torch>=2.7.1",
+  "accelerate>=0.34.2",
 ]
 
 # Token-level RAG hallucination detection (LettuceDetect guardrail).


### PR DESCRIPTION
## Summary

`any-guardrail[flowjudge]` → `flow-judge[hf]` → `bitsandbytes<=0.42.0,>=0.41.0` (Jan 2024), which aborts at import on CUDA>=12. Because a *broken* (not just outdated) bitsandbytes install poisons `transformers.integrations.bitsandbytes` for the whole process, installing the `flowjudge` extra could break a completely unrelated guardrail (e.g. `gpt_oss_safeguard`) with a traceback naming neither bitsandbytes nor flow-judge.

Verified directly against the installed `flow-judge` 0.1.2 package (confirmed no newer PyPI release exists that relaxes the cap): its `Hf` backend (`flow_judge/models/huggingface.py`) never imports or references `bitsandbytes` anywhere — only `torch`, `huggingface_hub`, `transformers`. It's declared in flow-judge's own `hf` extra but is dead weight for the code path any-guardrail actually exercises (only relevant for 4/8-bit quantized loading, which isn't wired up in that backend). `accelerate` **is** genuinely needed (`device_map="auto"` is the default, which transformers requires `accelerate` to honor) and was the one real gap versus our own `huggingface` extra.

## Fix

Depend on `flow-judge` without the `[hf]` extra, and declare its real runtime needs (`transformers`, `torch`, `accelerate`) ourselves — using any-guardrail's own `huggingface` extra floor versions for consistency — omitting `bitsandbytes` entirely so it's simply never installed. No upstream fix needed.

## Test plan
- [x] `uv sync --extra flowjudge` resolves with no `bitsandbytes` in the environment
- [x] `flow_judge.models.huggingface.HF_AVAILABLE` still reports `True` (confirms the `Hf` backend's own import guard is satisfied without bitsandbytes)
- [x] `pytest -v tests/unit` (1088 passed) and `pytest -v tests/docs` (59 passed)
- [x] `pre-commit run --all-files`
- [ ] Real verification of the CUDA>=12 collateral-damage fix isn't possible without a CUDA>=12 host — the above confirms the dependency is gone, which is the actual fix

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)