### PR TITLE
feat: add AnyGuardrail.evaluate() dispatcher for uniform judge invocation (#230)

### DIFF
--- a/src/any_guardrail/__init__.py
+++ b/src/any_guardrail/__init__.py
@@ -1,6 +1,7 @@
 from .api import AnyGuardrail
 from .base import Guardrail, GuardrailName, ThreeStageGuardrail
 from .content_registry import CONTENT_REGISTRY
+from .evaluate import EvaluateArgumentError
 from .prompt_registry import PROMPT_REGISTRY
 from .providers import HuggingFaceProvider, Provider
 from .registry import GUARDRAIL_METADATA
@@ -45,6 +46,7 @@ __all__ = [
     "ChatMessage",
     "ChatMessages",
     "ContentKind",
+    "EvaluateArgumentError",
     "Guardrail",
     "GuardrailCategory",
     "GuardrailInferenceOutput",

--- a/src/any_guardrail/api.py
+++ b/src/any_guardrail/api.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import any_guardrail.content_registry as _content
 from any_guardrail.base import Guardrail, GuardrailName
+from any_guardrail.evaluate import build_validate_call
 from any_guardrail.parameter_registry import get_parameter_schema as _registry_get_parameter_schema
 from any_guardrail.parameter_registry import get_requirement_groups as _registry_get_requirement_groups
 from any_guardrail.parameters import ParameterSpec, RequirementGroup
@@ -21,6 +22,7 @@ from any_guardrail.taxonomy import (
     GuardrailStage,
     OutputShape,
 )
+from any_guardrail.types import GuardrailOutput
 
 # Metadata dimensions that hold a set of values (matched by any-overlap) vs a
 # single scalar value (matched by equality) when filtering / grouping.
@@ -317,6 +319,49 @@ class AnyGuardrail:
         if provider is not None:
             kwargs["provider"] = provider
         return guardrail_class(**kwargs)
+
+    @classmethod
+    def evaluate(
+        cls,
+        guardrail_name: GuardrailName,
+        guardrail: Guardrail,
+        prompt: str,
+        response: str | None = None,
+        **kwargs: Any,
+    ) -> GuardrailOutput | list[GuardrailOutput]:
+        """Drive any guardrail's ``validate()`` through one generic ``(prompt, response)`` call.
+
+        Judges come in several incompatible ``validate()`` shapes (text-pair, single-input,
+        keyed-dict, signature-locked pairs with a different parameter name). This maps a
+        generic call onto whichever shape ``guardrail_name`` actually uses, so callers that
+        want to drive judges interchangeably don't have to hard-code that mapping themselves.
+
+        Args:
+            guardrail_name: Which guardrail ``guardrail`` is an instance of (module->class
+                resolution isn't cleanly invertible from the instance alone, so this is
+                required rather than inferred from ``type(guardrail)``).
+            guardrail: An already-constructed guardrail instance (e.g. from ``create()``).
+                Constructor-only configuration (like ``gpt_oss_safeguard``'s ``policy``) is
+                unaffected since it was already baked in at construction time.
+            prompt: The primary text — the request/instruction/question being judged. Ignored
+                for guardrails with no free-text primary role (currently only ``flowjudge``,
+                which is documented as such).
+            response: The response/answer text being judged alongside ``prompt``, for
+                guardrails that support a response slot. ``None`` for a prompt-only call.
+            **kwargs: Extra arguments forwarded to ``validate()`` as-is (e.g. ``documents``,
+                ``inputs`` for ``flowjudge``, ``policy`` for ``any_llm``).
+
+        Returns:
+            Whatever ``guardrail.validate(...)`` returns.
+
+        Raises:
+            EvaluateArgumentError: If ``response`` is supplied for a guardrail with no
+                response slot, or if an argument the guardrail's ``validate()`` requires is
+                still missing after mapping the call.
+
+        """
+        args, call_kwargs = build_validate_call(guardrail_name, guardrail, prompt, response, kwargs)
+        return guardrail.validate(*args, **call_kwargs)
 
     @classmethod
     def _get_guardrail_class(cls, guardrail_name: GuardrailName) -> type[Guardrail]:

--- a/src/any_guardrail/evaluate.py
+++ b/src/any_guardrail/evaluate.py
@@ -1,0 +1,182 @@
+"""Uniform (prompt, response) dispatcher for driving any guardrail's validate() (issue #230).
+
+Judges come in at least six incompatible ``validate()`` shapes: text-pair
+(``input_text``/``output_text``), text-pair plus structured kwargs, single-input,
+union-typed primary argument, keyed-dict (FlowJudge), and signature-locked pairs
+with a different parameter name (OffTopic, LettuceDetect). A caller that wants to
+drive judges interchangeably has to hard-code that mapping itself, and the
+``**kwargs`` variants mean a typo'd argument is silently ignored rather than
+rejected.
+
+``build_validate_call`` centralizes that mapping in one tested, versioned place
+instead of leaving every downstream consumer to duplicate (and get wrong) which
+argument name is "the response" for each guardrail. It does not remove the
+underlying heterogeneity — each guardrail's own ``validate()`` is unchanged —
+it only builds the ``(args, kwargs)`` to call it with from a generic
+``(prompt, response)`` pair, using the existing ``required_validate_kwargs``
+metadata to fail with a clear error instead of a raw ``TypeError`` when something
+required is missing.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+from any_guardrail.base import Guardrail, GuardrailName
+from any_guardrail.registry import GUARDRAIL_METADATA
+
+_Builder = Callable[[GuardrailName, Guardrail, str, str | None, dict[str, Any]], tuple[tuple[Any, ...], dict[str, Any]]]
+
+
+class EvaluateArgumentError(ValueError):
+    """Raised when a call to ``AnyGuardrail.evaluate()`` doesn't supply what the guardrail needs."""
+
+
+def _pair(response_kwarg: str) -> _Builder:
+    """Builder for ``validate(prompt, **{response_kwarg: response}, **kwargs)`` shapes."""
+
+    def build(
+        name: GuardrailName, guardrail: Guardrail, prompt: str, response: str | None, kwargs: dict[str, Any]
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        del name, guardrail
+        call_kwargs = dict(kwargs)
+        if response is not None:
+            call_kwargs[response_kwarg] = response
+        return (prompt,), call_kwargs
+
+    return build
+
+
+def _single() -> _Builder:
+    """Builder for ``validate(prompt, **kwargs)`` shapes with no response/second-text slot."""
+
+    def build(
+        name: GuardrailName, guardrail: Guardrail, prompt: str, response: str | None, kwargs: dict[str, Any]
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        del guardrail
+        if response is not None:
+            msg = (
+                f"{name.value}.validate() has no response/second-text argument; "
+                f"got response={response!r}. Pass extra arguments via evaluate(..., **kwargs) instead."
+            )
+            raise EvaluateArgumentError(msg)
+        return (prompt,), dict(kwargs)
+
+    return build
+
+
+def _lettuce_detect(
+    name: GuardrailName, guardrail: Guardrail, prompt: str, response: str | None, kwargs: dict[str, Any]
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """LettuceDetect's roles are swapped: its primary positional is the answer being checked.
+
+    ``response`` (the answer) fills the primary positional; ``prompt`` (the question the
+    answer responds to) fills the ``question`` kwarg; ``context`` (required) must come via
+    ``**kwargs``.
+    """
+    del guardrail
+    if response is None:
+        msg = (
+            f"{name.value}.validate() requires `response` (the answer to check for "
+            "hallucinations) via evaluate(..., response=...)."
+        )
+        raise EvaluateArgumentError(msg)
+    call_kwargs = {**kwargs, "question": prompt}
+    return (response,), call_kwargs
+
+
+def _flowjudge(
+    name: GuardrailName, guardrail: Guardrail, prompt: str, response: str | None, kwargs: dict[str, Any]
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """FlowJudge has no free-text primary argument; ``prompt`` doesn't map onto its keyed dicts.
+
+    Callers must pass ``inputs=[...]`` (a ``list[dict[str, str]]`` matching the guardrail's
+    ``required_inputs``) via ``**kwargs`` — checked explicitly here since ``inputs`` is the
+    primary positional and isn't tracked by ``required_validate_kwargs``. ``response`` fills
+    ``output={guardrail.required_output: response}`` when given and not already supplied.
+    """
+    del prompt
+    if "inputs" not in kwargs:
+        msg = (
+            f"{name.value}.validate() requires `inputs` (a list[dict[str, str]] matching "
+            "required_inputs) via evaluate(..., inputs=[...])."
+        )
+        raise EvaluateArgumentError(msg)
+    call_kwargs = dict(kwargs)
+    inputs = call_kwargs.pop("inputs")
+    if response is not None and "output" not in call_kwargs:
+        call_kwargs["output"] = {getattr(guardrail, "required_output"): response}  # noqa: B009
+    return (inputs,), call_kwargs
+
+
+_BUILDERS: dict[GuardrailName, _Builder] = {
+    # Text-pair: validate(input_text, output_text=None, **kwargs) (or no **kwargs).
+    GuardrailName.GLIDER: _pair("output_text"),
+    GuardrailName.HARMGUARD: _pair("output_text"),
+    GuardrailName.DYNA_GUARD: _pair("output_text"),
+    GuardrailName.COMPASS_JUDGER: _pair("output_text"),
+    GuardrailName.PROMETHEUS: _pair("output_text"),
+    GuardrailName.NEMOTRON_CONTENT_SAFETY: _pair("output_text"),
+    GuardrailName.KANANA_SAFEGUARD: _pair("output_text"),
+    GuardrailName.QWEN3_GUARD: _pair("output_text"),
+    GuardrailName.POLY_GUARD: _pair("output_text"),
+    GuardrailName.QWEN3_GUARD_STREAM: _pair("output_text"),
+    GuardrailName.WILD_GUARD: _pair("output_text"),
+    GuardrailName.SELENE: _pair("output_text"),
+    GuardrailName.LLAMA_GUARD: _pair("output_text"),
+    GuardrailName.GRANITE_GUARDIAN: _pair("output_text"),
+    GuardrailName.PATRONUS: _pair("output_text"),
+    # Text-pair with a differently-named response kwarg.
+    GuardrailName.ALINIA: _pair("output"),
+    GuardrailName.OFFTOPIC: _pair("comparison_text"),
+    # Single input, no response/second-text slot.
+    GuardrailName.BEDROCK_GUARDRAILS: _single(),
+    GuardrailName.DEEPSET: _single(),
+    GuardrailName.DUOGUARD: _single(),
+    GuardrailName.INJECGUARD: _single(),
+    GuardrailName.JASPER: _single(),
+    GuardrailName.OPENAI_MODERATION: _single(),
+    GuardrailName.PANGOLIN: _single(),
+    GuardrailName.PROTECTAI: _single(),
+    GuardrailName.SENTINEL: _single(),
+    GuardrailName.SHIELD_GEMMA: _single(),
+    GuardrailName.PROMPT_GUARD: _single(),
+    GuardrailName.BIELIK_GUARD: _single(),
+    GuardrailName.AZURE_CONTENT_SAFETY: _single(),
+    GuardrailName.WATSONX_GUARDIAN: _single(),
+    GuardrailName.GLI_GUARD: _single(),
+    GuardrailName.GPT_OSS_SAFEGUARD: _single(),
+    GuardrailName.GLI_NER_PII: _single(),
+    GuardrailName.ANYLLM: _single(),
+    GuardrailName.LAKERA_GUARD: _single(),
+    GuardrailName.AZURE_PROMPT_SHIELDS: _single(),
+    # Bespoke shapes.
+    GuardrailName.LETTUCE_DETECT: _lettuce_detect,
+    GuardrailName.FLOWJUDGE: _flowjudge,
+}
+
+
+def build_validate_call(
+    name: GuardrailName,
+    guardrail: Guardrail,
+    prompt: str,
+    response: str | None,
+    kwargs: dict[str, Any],
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Map a generic ``(prompt, response, **kwargs)`` call onto ``guardrail``'s actual ``validate()`` shape.
+
+    Raises:
+        EvaluateArgumentError: If ``response`` is supplied for a guardrail with no
+            response slot, or if a kwarg the guardrail's ``validate()`` requires
+            (per ``GUARDRAIL_METADATA[name].required_validate_kwargs``) is still
+            missing after building the call.
+
+    """
+    args, call_kwargs = _BUILDERS[name](name, guardrail, prompt, response, kwargs)
+    missing = GUARDRAIL_METADATA[name].required_validate_kwargs - call_kwargs.keys()
+    if missing:
+        msg = (
+            f"{name.value}.validate() requires {sorted(missing)}; pass via "
+            "evaluate(..., response=...) or **kwargs."
+        )
+        raise EvaluateArgumentError(msg)
+    return args, call_kwargs

--- a/src/any_guardrail/evaluate.py
+++ b/src/any_guardrail/evaluate.py
@@ -39,7 +39,7 @@ def _pair(response_kwarg: str) -> _Builder:
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         del name, guardrail
         call_kwargs = dict(kwargs)
-        if response is not None:
+        if response is not None and response_kwarg not in call_kwargs:
             call_kwargs[response_kwarg] = response
         return (prompt,), call_kwargs
 
@@ -80,7 +80,8 @@ def _lettuce_detect(
             "hallucinations) via evaluate(..., response=...)."
         )
         raise EvaluateArgumentError(msg)
-    call_kwargs = {**kwargs, "question": prompt}
+    call_kwargs = dict(kwargs)
+    call_kwargs.setdefault("question", prompt)
     return (response,), call_kwargs
 
 
@@ -174,9 +175,6 @@ def build_validate_call(
     args, call_kwargs = _BUILDERS[name](name, guardrail, prompt, response, kwargs)
     missing = GUARDRAIL_METADATA[name].required_validate_kwargs - call_kwargs.keys()
     if missing:
-        msg = (
-            f"{name.value}.validate() requires {sorted(missing)}; pass via "
-            "evaluate(..., response=...) or **kwargs."
-        )
+        msg = f"{name.value}.validate() requires {sorted(missing)}; pass via evaluate(..., response=...) or **kwargs."
         raise EvaluateArgumentError(msg)
     return args, call_kwargs

--- a/tests/unit/test_evaluate.py
+++ b/tests/unit/test_evaluate.py
@@ -93,6 +93,13 @@ def test_granite_guardian_extra_kwargs_pass_through() -> None:
     guardrail.validate.assert_called_once_with("P", documents=[{"text": "doc"}], output_text="R")
 
 
+def test_pair_explicit_response_kwarg_wins_over_response() -> None:
+    """An explicitly-passed response kwarg takes precedence over the `response` positional."""
+    guardrail = _stub()
+    AnyGuardrail.evaluate(GuardrailName.PROMETHEUS, guardrail, "P", "ignored", output_text="explicit")
+    guardrail.validate.assert_called_once_with("P", output_text="explicit")
+
+
 def test_alinia_dispatch_uses_output_kwarg() -> None:
     guardrail = _stub()
     AnyGuardrail.evaluate(GuardrailName.ALINIA, guardrail, "P", "R", context_documents=["doc"])
@@ -159,6 +166,19 @@ def test_lettuce_detect_dispatch_swaps_prompt_and_response_roles() -> None:
     guardrail.validate.assert_called_once_with("Paris", question="What is the capital?", context="France...")
 
 
+def test_lettuce_detect_explicit_question_kwarg_wins_over_prompt() -> None:
+    guardrail = _stub()
+    AnyGuardrail.evaluate(
+        GuardrailName.LETTUCE_DETECT,
+        guardrail,
+        "ignored prompt",
+        "Paris",
+        context="France...",
+        question="explicit question",
+    )
+    guardrail.validate.assert_called_once_with("Paris", context="France...", question="explicit question")
+
+
 def test_lettuce_detect_missing_response_raises() -> None:
     guardrail = _stub()
     with pytest.raises(EvaluateArgumentError, match="response"):
@@ -176,9 +196,7 @@ def test_lettuce_detect_missing_context_raises() -> None:
 def test_flowjudge_dispatch_builds_output_from_response() -> None:
     guardrail = _stub()
     guardrail.required_output = "response"
-    AnyGuardrail.evaluate(
-        GuardrailName.FLOWJUDGE, guardrail, "unused prompt", "The answer", inputs=[{"query": "Q"}]
-    )
+    AnyGuardrail.evaluate(GuardrailName.FLOWJUDGE, guardrail, "unused prompt", "The answer", inputs=[{"query": "Q"}])
     guardrail.validate.assert_called_once_with([{"query": "Q"}], output={"response": "The answer"})
 
 

--- a/tests/unit/test_evaluate.py
+++ b/tests/unit/test_evaluate.py
@@ -1,0 +1,212 @@
+"""Tests for the AnyGuardrail.evaluate() dispatcher (issue #230)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from any_guardrail import AnyGuardrail, EvaluateArgumentError, GuardrailName
+from any_guardrail.evaluate import _BUILDERS
+
+PAIR_OUTPUT_TEXT = [
+    GuardrailName.GLIDER,
+    GuardrailName.HARMGUARD,
+    GuardrailName.DYNA_GUARD,
+    GuardrailName.COMPASS_JUDGER,
+    GuardrailName.PROMETHEUS,
+    GuardrailName.NEMOTRON_CONTENT_SAFETY,
+    GuardrailName.KANANA_SAFEGUARD,
+    GuardrailName.QWEN3_GUARD,
+    GuardrailName.POLY_GUARD,
+    GuardrailName.QWEN3_GUARD_STREAM,
+    GuardrailName.WILD_GUARD,
+    GuardrailName.SELENE,
+    GuardrailName.LLAMA_GUARD,
+    GuardrailName.GRANITE_GUARDIAN,
+    GuardrailName.PATRONUS,
+]
+
+# The `_single()` bucket, minus ANYLLM (requires `policy`, tested separately).
+SINGLE_NO_REQUIRED_KWARGS = [
+    GuardrailName.BEDROCK_GUARDRAILS,
+    GuardrailName.DEEPSET,
+    GuardrailName.DUOGUARD,
+    GuardrailName.INJECGUARD,
+    GuardrailName.JASPER,
+    GuardrailName.OPENAI_MODERATION,
+    GuardrailName.PANGOLIN,
+    GuardrailName.PROTECTAI,
+    GuardrailName.SENTINEL,
+    GuardrailName.SHIELD_GEMMA,
+    GuardrailName.PROMPT_GUARD,
+    GuardrailName.BIELIK_GUARD,
+    GuardrailName.AZURE_CONTENT_SAFETY,
+    GuardrailName.WATSONX_GUARDIAN,
+    GuardrailName.GLI_GUARD,
+    GuardrailName.GPT_OSS_SAFEGUARD,
+    GuardrailName.GLI_NER_PII,
+    GuardrailName.LAKERA_GUARD,
+    GuardrailName.AZURE_PROMPT_SHIELDS,
+]
+
+ALL_COVERED = {
+    *PAIR_OUTPUT_TEXT,
+    *SINGLE_NO_REQUIRED_KWARGS,
+    GuardrailName.ALINIA,
+    GuardrailName.OFFTOPIC,
+    GuardrailName.ANYLLM,
+    GuardrailName.LETTUCE_DETECT,
+    GuardrailName.FLOWJUDGE,
+}
+
+
+def test_evaluate_covers_all_guardrails_exactly() -> None:
+    """Every GuardrailName has exactly one dispatch builder, and vice versa."""
+    assert set(_BUILDERS) == set(GuardrailName)
+
+
+def test_local_guardrail_lists_cover_every_name() -> None:
+    """Sanity check that this test file's own groupings haven't drifted from the full set."""
+    assert ALL_COVERED == set(GuardrailName)
+
+
+def _stub() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.mark.parametrize("name", PAIR_OUTPUT_TEXT, ids=lambda n: n.value)
+def test_pair_output_text_dispatch_with_response(name: GuardrailName) -> None:
+    guardrail = _stub()
+    AnyGuardrail.evaluate(name, guardrail, "P", "R")
+    guardrail.validate.assert_called_once_with("P", output_text="R")
+
+
+@pytest.mark.parametrize("name", PAIR_OUTPUT_TEXT, ids=lambda n: n.value)
+def test_pair_output_text_dispatch_without_response(name: GuardrailName) -> None:
+    guardrail = _stub()
+    AnyGuardrail.evaluate(name, guardrail, "P")
+    guardrail.validate.assert_called_once_with("P")
+
+
+def test_granite_guardian_extra_kwargs_pass_through() -> None:
+    guardrail = _stub()
+    AnyGuardrail.evaluate(GuardrailName.GRANITE_GUARDIAN, guardrail, "P", "R", documents=[{"text": "doc"}])
+    guardrail.validate.assert_called_once_with("P", documents=[{"text": "doc"}], output_text="R")
+
+
+def test_alinia_dispatch_uses_output_kwarg() -> None:
+    guardrail = _stub()
+    AnyGuardrail.evaluate(GuardrailName.ALINIA, guardrail, "P", "R", context_documents=["doc"])
+    guardrail.validate.assert_called_once_with("P", context_documents=["doc"], output="R")
+
+
+def test_alinia_dispatch_without_response() -> None:
+    guardrail = _stub()
+    AnyGuardrail.evaluate(GuardrailName.ALINIA, guardrail, "P")
+    guardrail.validate.assert_called_once_with("P")
+
+
+def test_offtopic_dispatch_uses_comparison_text_kwarg() -> None:
+    guardrail = _stub()
+    AnyGuardrail.evaluate(GuardrailName.OFFTOPIC, guardrail, "P", "R")
+    guardrail.validate.assert_called_once_with("P", comparison_text="R")
+
+
+def test_offtopic_missing_response_raises() -> None:
+    guardrail = _stub()
+    with pytest.raises(EvaluateArgumentError, match="comparison_text"):
+        AnyGuardrail.evaluate(GuardrailName.OFFTOPIC, guardrail, "P")
+    guardrail.validate.assert_not_called()
+
+
+@pytest.mark.parametrize("name", SINGLE_NO_REQUIRED_KWARGS, ids=lambda n: n.value)
+def test_single_dispatch(name: GuardrailName) -> None:
+    guardrail = _stub()
+    AnyGuardrail.evaluate(name, guardrail, "P")
+    guardrail.validate.assert_called_once_with("P")
+
+
+@pytest.mark.parametrize("name", SINGLE_NO_REQUIRED_KWARGS, ids=lambda n: n.value)
+def test_single_rejects_response(name: GuardrailName) -> None:
+    guardrail = _stub()
+    with pytest.raises(EvaluateArgumentError, match="response"):
+        AnyGuardrail.evaluate(name, guardrail, "P", "R")
+    guardrail.validate.assert_not_called()
+
+
+def test_gli_ner_pii_extra_kwargs_pass_through() -> None:
+    guardrail = _stub()
+    AnyGuardrail.evaluate(GuardrailName.GLI_NER_PII, guardrail, "P", entity_types=["PERSON"], threshold=0.5)
+    guardrail.validate.assert_called_once_with("P", entity_types=["PERSON"], threshold=0.5)
+
+
+def test_any_llm_dispatch_with_policy() -> None:
+    guardrail = _stub()
+    AnyGuardrail.evaluate(GuardrailName.ANYLLM, guardrail, "P", policy="Be nice")
+    guardrail.validate.assert_called_once_with("P", policy="Be nice")
+
+
+def test_any_llm_missing_policy_raises() -> None:
+    guardrail = _stub()
+    with pytest.raises(EvaluateArgumentError, match="policy"):
+        AnyGuardrail.evaluate(GuardrailName.ANYLLM, guardrail, "P")
+    guardrail.validate.assert_not_called()
+
+
+def test_lettuce_detect_dispatch_swaps_prompt_and_response_roles() -> None:
+    """LettuceDetect's own validate() takes the answer as input_text and the question as a kwarg."""
+    guardrail = _stub()
+    AnyGuardrail.evaluate(GuardrailName.LETTUCE_DETECT, guardrail, "What is the capital?", "Paris", context="France...")
+    guardrail.validate.assert_called_once_with("Paris", question="What is the capital?", context="France...")
+
+
+def test_lettuce_detect_missing_response_raises() -> None:
+    guardrail = _stub()
+    with pytest.raises(EvaluateArgumentError, match="response"):
+        AnyGuardrail.evaluate(GuardrailName.LETTUCE_DETECT, guardrail, "What is the capital?", context="France...")
+    guardrail.validate.assert_not_called()
+
+
+def test_lettuce_detect_missing_context_raises() -> None:
+    guardrail = _stub()
+    with pytest.raises(EvaluateArgumentError, match="context"):
+        AnyGuardrail.evaluate(GuardrailName.LETTUCE_DETECT, guardrail, "What is the capital?", "Paris")
+    guardrail.validate.assert_not_called()
+
+
+def test_flowjudge_dispatch_builds_output_from_response() -> None:
+    guardrail = _stub()
+    guardrail.required_output = "response"
+    AnyGuardrail.evaluate(
+        GuardrailName.FLOWJUDGE, guardrail, "unused prompt", "The answer", inputs=[{"query": "Q"}]
+    )
+    guardrail.validate.assert_called_once_with([{"query": "Q"}], output={"response": "The answer"})
+
+
+def test_flowjudge_missing_inputs_raises() -> None:
+    guardrail = _stub()
+    guardrail.required_output = "response"
+    with pytest.raises(EvaluateArgumentError, match="inputs"):
+        AnyGuardrail.evaluate(GuardrailName.FLOWJUDGE, guardrail, "P", "R")
+    guardrail.validate.assert_not_called()
+
+
+def test_flowjudge_missing_output_raises_when_no_response() -> None:
+    guardrail = _stub()
+    guardrail.required_output = "response"
+    with pytest.raises(EvaluateArgumentError, match="output"):
+        AnyGuardrail.evaluate(GuardrailName.FLOWJUDGE, guardrail, "P", inputs=[{"query": "Q"}])
+    guardrail.validate.assert_not_called()
+
+
+def test_flowjudge_explicit_output_kwarg_wins_over_response() -> None:
+    guardrail = _stub()
+    guardrail.required_output = "response"
+    AnyGuardrail.evaluate(
+        GuardrailName.FLOWJUDGE,
+        guardrail,
+        "P",
+        "ignored",
+        inputs=[{"query": "Q"}],
+        output={"response": "explicit"},
+    )
+    guardrail.validate.assert_called_once_with([{"query": "Q"}], output={"response": "explicit"})


### PR DESCRIPTION
## Summary

Judges come in at least six incompatible `validate()` shapes: text-pair (`input_text`/`output_text`), text-pair with a differently-named response kwarg (Alinia's `output`, OffTopic's `comparison_text`), single-input, a union-typed primary argument, keyed-dict (FlowJudge's `inputs`/`output`), and a signature-locked pair with swapped roles (LettuceDetect, whose `input_text` is actually the answer being checked, not the question). Every consumer driving judges interchangeably has had to hard-code that mapping — three adapter classes plus a membership set, per the issue — and the `**kwargs`-accepting guardrails mean a typo'd argument is silently ignored rather than rejected.

Per the smaller of the issue's two proposed fixes: add `AnyGuardrail.evaluate()` rather than unifying `validate()` signatures across ~20 guardrail files (much larger blast radius, higher regression risk). No existing guardrail's `validate()` changes.

## Changes
- New `src/any_guardrail/evaluate.py`: a 39-row dispatch table (`_BUILDERS`) mapping each `GuardrailName` to a small builder function, plus `build_validate_call()` which maps a generic `(prompt, response, **kwargs)` call onto the guardrail's actual shape and uses the existing `required_validate_kwargs` metadata to raise a clear `EvaluateArgumentError` instead of a raw `TypeError` when something required is still missing (Alinia's response slot, OffTopic's `comparison_text`, `any_llm`'s `policy`, LettuceDetect's `context`, FlowJudge's `inputs`/`output`).
- `AnyGuardrail.evaluate(guardrail_name, guardrail, prompt, response=None, **kwargs)` in `api.py`, dispatching through the table.
- `EvaluateArgumentError` exported from the package root.
- Every `validate()` signature was verified directly against current source (not assumed from the issue's own table) before building the mapping — three signature shapes needed special handling beyond the issue's write-up: `patronus`/`glider`/`harm_guard` have no `**kwargs` (fine, since the builder only ever adds a real named parameter), and `flowjudge`'s `inputs` argument isn't tracked by `required_validate_kwargs` at all (it's the primary positional), so it gets an explicit check in its bespoke builder.

## Test plan
- [x] `pytest -v tests/unit` (1234 passed) and `pytest -v tests/docs`
- [x] `pre-commit run --all-files`
- [x] Parity test: every `GuardrailName` has exactly one dispatch builder
- [x] Parametrized dispatch tests for all 15 text-pair guardrails (with and without a response) and all 19 single-input guardrails (dispatch + response-rejection)
- [x] Dedicated tests for each bespoke shape: Alinia (`output` kwarg), OffTopic (`comparison_text` kwarg + missing-response error), `any_llm` (`policy` required), LettuceDetect (role-swapped dispatch + missing-response/-context errors), FlowJudge (`inputs`/`output` construction, missing-`inputs` error, missing-`output`-when-no-response error, explicit `output` kwarg taking precedence over `response`)

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)