### PR TITLE
fix(kanana-safeguard): drop unloadable prompt-2.1b variant

### DIFF
--- a/docs/api/guardrails/index.md
+++ b/docs/api/guardrails/index.md
@@ -31,7 +31,7 @@ Query this catalog programmatically with `AnyGuardrail.list_guardrails(...)` and
 | [DuoGuard](duo-guard.md) | Multilingual multi-label safety classifier scoring text across 12 harm categories including jailbreak prompts. |
 | [GLiGuard](gli-guard.md) | Schema-driven safety, toxicity, jailbreak, and refusal detector. |
 | [gpt-oss-safeguard](gpt-oss-safeguard.md) | Policy-grounded reasoning safety classifier that judges text against a bring-your-own written policy. |
-| [Kanana Safeguard](kanana-safeguard.md) | Korean safety decoder models covering harmful content, legal risk, and prompt attacks. |
+| [Kanana Safeguard](kanana-safeguard.md) | Korean safety decoder models covering harmful content and legal risk. |
 | [Llama Guard](llama-guard.md) | Decoder-LLM safety classifier judging prompts and responses against the 14-category MLCommons hazard taxonomy. |
 | [Nemotron Content Safety](nemotron-content-safety.md) | Reasoning safety classifier covering a 22-category content-safety taxonomy. |
 | [OpenAI Moderation](openai-moderation.md) | Hosted moderation API flagging content across 13 harm categories with calibrated scores. |

--- a/docs/api/guardrails/kanana-safeguard.md
+++ b/docs/api/guardrails/kanana-safeguard.md
@@ -1,6 +1,6 @@
 # KananaSafeguard
 
-Korean safety decoder models covering harmful content, legal risk, and prompt attacks.
+Korean safety decoder models covering harmful content and legal risk.
 
 Decoder LLMs, trained primarily for Korean text, that emit a single verdict token:
 ``<SAFE>`` or an ``<UNSAFE-*>`` code. Two variants cover different taxonomies:

--- a/docs/api/guardrails/kanana-safeguard.md
+++ b/docs/api/guardrails/kanana-safeguard.md
@@ -3,15 +3,13 @@
 Korean safety decoder models covering harmful content, legal risk, and prompt attacks.
 
 Decoder LLMs, trained primarily for Korean text, that emit a single verdict token:
-``<SAFE>`` or an ``<UNSAFE-*>`` code. Three variants cover different taxonomies:
+``<SAFE>`` or an ``<UNSAFE-*>`` code. Two variants cover different taxonomies:
 
 - ``kakaocorp/kanana-safeguard-8b`` (default): harmful content — Hate, Harassment,
   Sexual Content, Crime, Child Sexual Abuse, Self-Harm, Misinformation (``S1``-``S7``).
   The only variant trained to also judge an assistant turn (``output_text``).
 - ``kakaocorp/kanana-safeguard-siren-8b``: legal/policy risk — Adult Authentication,
   Professional Advice, Personal Information, Intellectual Property (``I1``-``I4``).
-- ``kakaocorp/kanana-safeguard-prompt-2.1b``: prompt attacks — Prompt Injection,
-  Prompt Leaking (``A1``-``A2``).
 
 Inputs are single strings (no batching): ``validate(input_text)`` for the user turn,
 plus an optional assistant ``output_text`` that is only used by the harm (``-8b``)
@@ -28,19 +26,17 @@ For more information, see:
 
 - [kanana-safeguard-8b](https://huggingface.co/kakaocorp/kanana-safeguard-8b) (default).
 - [kanana-safeguard-siren-8b](https://huggingface.co/kakaocorp/kanana-safeguard-siren-8b).
-- [kanana-safeguard-prompt-2.1b](https://huggingface.co/kakaocorp/kanana-safeguard-prompt-2.1b).
 
 ## Supported Models
 
 - `kakaocorp/kanana-safeguard-8b`
 - `kakaocorp/kanana-safeguard-siren-8b`
-- `kakaocorp/kanana-safeguard-prompt-2.1b`
 
 ## Constructor
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `model_id` | `str | None` | No | `None` | Optional HuggingFace model ID; one of ``SUPPORTED_MODELS`` (``kakaocorp/kanana-safeguard-8b``, ``kakaocorp/kanana-safeguard-siren-8b``, ``kakaocorp/kanana-safeguard-prompt-2.1b``). Defaults to the harm model ``kakaocorp/kanana-safeguard-8b``. Each variant carries its own unsafe-code taxonomy (see the class docstring). |
+| `model_id` | `str | None` | No | `None` | Optional HuggingFace model ID; one of ``SUPPORTED_MODELS`` (``kakaocorp/kanana-safeguard-8b``, ``kakaocorp/kanana-safeguard-siren-8b``). Defaults to the harm model ``kakaocorp/kanana-safeguard-8b``. Each variant carries its own unsafe-code taxonomy (see the class docstring). |
 | `provider` | `Provider[dict[str, Any], dict[str, Any]] | None` | No | `None` | Optional pre-configured provider (e.g. a ``LlamafileProvider`` or a customized ``HuggingFaceProvider``). Defaults to a ``HuggingFaceProvider``; when a ``HuggingFaceProvider`` is used, the causal-LM loader classes (``AutoModelForCausalLM`` + ``AutoTokenizer``) are enforced at load time. |
 
 Initialize the Kanana Safeguard guardrail.
@@ -54,7 +50,7 @@ Classify ``input_text`` (and, for the harm model, an assistant ``output_text``).
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `input_text` | `str` | Yes | — | The user turn to classify. Must be a single string — list (batch) inputs are not supported. Korean is the primary training language. |
-| `output_text` | `str | None` | No | `None` | Optional assistant response. Only the harm model (``kakaocorp/kanana-safeguard-8b``) is trained to judge an assistant turn; the ``-siren-8b`` and ``-prompt-2.1b`` variants silently ignore this argument. |
+| `output_text` | `str | None` | No | `None` | Optional assistant response. Only the harm model (``kakaocorp/kanana-safeguard-8b``) is trained to judge an assistant turn; the ``-siren-8b`` variant silently ignores this argument. |
 
 **Returns:** `GuardrailOutput`
 

--- a/schemas/guardrail_metadata.json
+++ b/schemas/guardrail_metadata.json
@@ -574,7 +574,7 @@
       "prompt_injection"
     ],
     "default_license": "apache-2.0",
-    "description": "Korean safety decoder models covering harmful content, legal risk, and prompt attacks.",
+    "description": "Korean safety decoder models covering harmful content and legal risk.",
     "display_name": "Kanana Safeguard",
     "multilingual": true,
     "multimodal": false,

--- a/schemas/guardrail_parameters.json
+++ b/schemas/guardrail_parameters.json
@@ -1204,11 +1204,10 @@
       {
         "choices": [
           "kakaocorp/kanana-safeguard-8b",
-          "kakaocorp/kanana-safeguard-siren-8b",
-          "kakaocorp/kanana-safeguard-prompt-2.1b"
+          "kakaocorp/kanana-safeguard-siren-8b"
         ],
         "default": null,
-        "description": "Optional HuggingFace model ID; one of ``SUPPORTED_MODELS`` (``kakaocorp/kanana-safeguard-8b``, ``kakaocorp/kanana-safeguard-siren-8b``, ``kakaocorp/kanana-safeguard-prompt-2.1b``). Defaults to the harm model ``kakaocorp/kanana-safeguard-8b``. Each variant carries its own unsafe-code taxonomy (see the class docstring).",
+        "description": "Optional HuggingFace model ID; one of ``SUPPORTED_MODELS`` (``kakaocorp/kanana-safeguard-8b``, ``kakaocorp/kanana-safeguard-siren-8b``). Defaults to the harm model ``kakaocorp/kanana-safeguard-8b``. Each variant carries its own unsafe-code taxonomy (see the class docstring).",
         "effectively_required": false,
         "env_var": null,
         "name": "model_id",
@@ -1220,7 +1219,7 @@
       {
         "choices": null,
         "default": null,
-        "description": "Optional assistant response. Only the harm model (``kakaocorp/kanana-safeguard-8b``) is trained to judge an assistant turn; the ``-siren-8b`` and ``-prompt-2.1b`` variants silently ignore this argument.",
+        "description": "Optional assistant response. Only the harm model (``kakaocorp/kanana-safeguard-8b``) is trained to judge an assistant turn; the ``-siren-8b`` variant silently ignores this argument.",
         "effectively_required": false,
         "env_var": null,
         "name": "output_text",

--- a/src/any_guardrail/_parameter_data.py
+++ b/src/any_guardrail/_parameter_data.py
@@ -1157,11 +1157,10 @@ _PARAMETER_DATA_JSON = r"""
     {
       "choices": [
         "kakaocorp/kanana-safeguard-8b",
-        "kakaocorp/kanana-safeguard-siren-8b",
-        "kakaocorp/kanana-safeguard-prompt-2.1b"
+        "kakaocorp/kanana-safeguard-siren-8b"
       ],
       "default": null,
-      "description": "Optional HuggingFace model ID; one of ``SUPPORTED_MODELS`` (``kakaocorp/kanana-safeguard-8b``, ``kakaocorp/kanana-safeguard-siren-8b``, ``kakaocorp/kanana-safeguard-prompt-2.1b``). Defaults to the harm model ``kakaocorp/kanana-safeguard-8b``. Each variant carries its own unsafe-code taxonomy (see the class docstring).",
+      "description": "Optional HuggingFace model ID; one of ``SUPPORTED_MODELS`` (``kakaocorp/kanana-safeguard-8b``, ``kakaocorp/kanana-safeguard-siren-8b``). Defaults to the harm model ``kakaocorp/kanana-safeguard-8b``. Each variant carries its own unsafe-code taxonomy (see the class docstring).",
       "effectively_required": false,
       "env_var": null,
       "name": "model_id",
@@ -1173,7 +1172,7 @@ _PARAMETER_DATA_JSON = r"""
     {
       "choices": null,
       "default": null,
-      "description": "Optional assistant response. Only the harm model (``kakaocorp/kanana-safeguard-8b``) is trained to judge an assistant turn; the ``-siren-8b`` and ``-prompt-2.1b`` variants silently ignore this argument.",
+      "description": "Optional assistant response. Only the harm model (``kakaocorp/kanana-safeguard-8b``) is trained to judge an assistant turn; the ``-siren-8b`` variant silently ignores this argument.",
       "effectively_required": false,
       "env_var": null,
       "name": "output_text",

--- a/src/any_guardrail/guardrails/kanana_safeguard/kanana_safeguard.py
+++ b/src/any_guardrail/guardrails/kanana_safeguard/kanana_safeguard.py
@@ -46,7 +46,7 @@ _TOKEN_PATTERN = re.compile(r"<(SAFE|UNSAFE-([A-Z]\d+))>")
 
 
 class KananaSafeguard(ThreeStageGuardrail[KananaPreprocessData, KananaInferenceData]):
-    """Korean safety decoder models covering harmful content, legal risk, and prompt attacks.
+    """Korean safety decoder models covering harmful content and legal risk.
 
     Decoder LLMs, trained primarily for Korean text, that emit a single verdict token:
     ``<SAFE>`` or an ``<UNSAFE-*>`` code. Two variants cover different taxonomies:

--- a/src/any_guardrail/guardrails/kanana_safeguard/kanana_safeguard.py
+++ b/src/any_guardrail/guardrails/kanana_safeguard/kanana_safeguard.py
@@ -37,10 +37,6 @@ KANANA_CATEGORIES: dict[str, dict[str, str]] = {
         "I3": "Personal Information",
         "I4": "Intellectual Property",
     },
-    "kakaocorp/kanana-safeguard-prompt-2.1b": {
-        "A1": "Prompt Injection",
-        "A2": "Prompt Leaking",
-    },
 }
 # The harm model is the only variant trained to judge an assistant turn.
 _EVALUATES_RESPONSE = frozenset({"kakaocorp/kanana-safeguard-8b"})
@@ -53,15 +49,13 @@ class KananaSafeguard(ThreeStageGuardrail[KananaPreprocessData, KananaInferenceD
     """Korean safety decoder models covering harmful content, legal risk, and prompt attacks.
 
     Decoder LLMs, trained primarily for Korean text, that emit a single verdict token:
-    ``<SAFE>`` or an ``<UNSAFE-*>`` code. Three variants cover different taxonomies:
+    ``<SAFE>`` or an ``<UNSAFE-*>`` code. Two variants cover different taxonomies:
 
     - ``kakaocorp/kanana-safeguard-8b`` (default): harmful content — Hate, Harassment,
       Sexual Content, Crime, Child Sexual Abuse, Self-Harm, Misinformation (``S1``-``S7``).
       The only variant trained to also judge an assistant turn (``output_text``).
     - ``kakaocorp/kanana-safeguard-siren-8b``: legal/policy risk — Adult Authentication,
       Professional Advice, Personal Information, Intellectual Property (``I1``-``I4``).
-    - ``kakaocorp/kanana-safeguard-prompt-2.1b``: prompt attacks — Prompt Injection,
-      Prompt Leaking (``A1``-``A2``).
 
     Inputs are single strings (no batching): ``validate(input_text)`` for the user turn,
     plus an optional assistant ``output_text`` that is only used by the harm (``-8b``)
@@ -78,7 +72,6 @@ class KananaSafeguard(ThreeStageGuardrail[KananaPreprocessData, KananaInferenceD
 
     - [kanana-safeguard-8b](https://huggingface.co/kakaocorp/kanana-safeguard-8b) (default).
     - [kanana-safeguard-siren-8b](https://huggingface.co/kakaocorp/kanana-safeguard-siren-8b).
-    - [kanana-safeguard-prompt-2.1b](https://huggingface.co/kakaocorp/kanana-safeguard-prompt-2.1b).
 
     Args:
         model_id: Optional HuggingFace model ID; one of ``SUPPORTED_MODELS``. Defaults to
@@ -92,7 +85,6 @@ class KananaSafeguard(ThreeStageGuardrail[KananaPreprocessData, KananaInferenceD
     SUPPORTED_MODELS: ClassVar = [
         "kakaocorp/kanana-safeguard-8b",
         "kakaocorp/kanana-safeguard-siren-8b",
-        "kakaocorp/kanana-safeguard-prompt-2.1b",
     ]
 
     METADATA: ClassVar[GuardrailMetadata] = GUARDRAIL_METADATA[GuardrailName.KANANA_SAFEGUARD]
@@ -102,10 +94,9 @@ class KananaSafeguard(ThreeStageGuardrail[KananaPreprocessData, KananaInferenceD
 
         Args:
             model_id: Optional HuggingFace model ID; one of ``SUPPORTED_MODELS``
-                (``kakaocorp/kanana-safeguard-8b``, ``kakaocorp/kanana-safeguard-siren-8b``,
-                ``kakaocorp/kanana-safeguard-prompt-2.1b``). Defaults to the harm model
-                ``kakaocorp/kanana-safeguard-8b``. Each variant carries its own unsafe-code
-                taxonomy (see the class docstring).
+                (``kakaocorp/kanana-safeguard-8b``, ``kakaocorp/kanana-safeguard-siren-8b``).
+                Defaults to the harm model ``kakaocorp/kanana-safeguard-8b``. Each variant
+                carries its own unsafe-code taxonomy (see the class docstring).
             provider: Optional pre-configured provider (e.g. a ``LlamafileProvider`` or a
                 customized ``HuggingFaceProvider``). Defaults to a ``HuggingFaceProvider``;
                 when a ``HuggingFaceProvider`` is used, the causal-LM loader classes
@@ -141,8 +132,7 @@ class KananaSafeguard(ThreeStageGuardrail[KananaPreprocessData, KananaInferenceD
                 inputs are not supported. Korean is the primary training language.
             output_text: Optional assistant response. Only the harm model
                 (``kakaocorp/kanana-safeguard-8b``) is trained to judge an assistant turn;
-                the ``-siren-8b`` and ``-prompt-2.1b`` variants silently ignore this
-                argument.
+                the ``-siren-8b`` variant silently ignores this argument.
             **kwargs: Forwarded to the base ``validate`` implementation.
 
         Returns:

--- a/src/any_guardrail/registry.py
+++ b/src/any_guardrail/registry.py
@@ -414,7 +414,7 @@ GUARDRAIL_METADATA: dict[GuardrailName, GuardrailMetadata] = {
         ),
     ),
     GuardrailName.KANANA_SAFEGUARD: GuardrailMetadata(
-        description="Korean safety decoder models covering harmful content, legal risk, and prompt attacks.",
+        description="Korean safety decoder models covering harmful content and legal risk.",
         display_name="Kanana Safeguard",
         categories=frozenset({GuardrailCategory.CONTENT_SAFETY, GuardrailCategory.PROMPT_INJECTION}),
         primary_category=GuardrailCategory.CONTENT_SAFETY,

--- a/tests/unit/test_unit_new_guardrails.py
+++ b/tests/unit/test_unit_new_guardrails.py
@@ -186,6 +186,14 @@ def test_kanana_fails_closed() -> None:
     assert result.extra == {"parse_failure": True}
 
 
+def test_kanana_prompt_2_1b_dropped_from_supported_models() -> None:
+    """An unloadable variant fails fast with a clear ValueError, not deep inside model loading."""
+    assert "kakaocorp/kanana-safeguard-prompt-2.1b" not in KananaSafeguard.SUPPORTED_MODELS
+    assert "kakaocorp/kanana-safeguard-prompt-2.1b" not in KANANA_CATEGORIES
+    with pytest.raises(ValueError, match="Only supports"):
+        KananaSafeguard(model_id="kakaocorp/kanana-safeguard-prompt-2.1b")
+
+
 @pytest.mark.parametrize(
     ("text", "expected_valid"),
     [


### PR DESCRIPTION
# Pull Request

## Description

Drops `kakaocorp/kanana-safeguard-prompt-2.1b` from `KananaSafeguard.SUPPORTED_MODELS`. Its published config declares `hidden_size=1792` with 24 attention heads (1792 / 24 = 74.67), which `huggingface_hub`'s strict-dataclass `validate_architecture` check rejects. Loading it currently fails deep inside `provider.load_model()` with a `StrictDataclassClassValidationError`, so anything that enumerates `SUPPORTED_MODELS` and tries each entry discovers this one by crashing.

Same shape as #228 (pangolin-guard-large) and #236 (Llama-Guard-4-12B), both already fixed by dropping the entry.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Fixes #239

## Changes Made

- Removed `kakaocorp/kanana-safeguard-prompt-2.1b` from `SUPPORTED_MODELS` and its `KANANA_CATEGORIES` entry
- Updated the class and `__init__`/`validate` docstrings (three variants to two, drop the `-prompt-2.1b` references)
- Regenerated `src/any_guardrail/_parameter_data.py`, `schemas/guardrail_parameters.json`, and `docs/api/guardrails/kanana-safeguard.md` for the removed entry
- Added a regression test asserting the model ID is gone from `SUPPORTED_MODELS`/`KANANA_CATEGORIES` and that instantiating with it now raises a clear `ValueError` instead of the strict-dataclass error

## Testing

- [x] Unit tests added/updated
- [x] All existing tests pass

Reproduced on current `main` in a clean container: `AnyGuardrail.create(GuardrailName.KANANA_SAFEGUARD, model_id="kakaocorp/kanana-safeguard-prompt-2.1b")` raises `StrictDataclassClassValidationError: ... The hidden size (1792) is not a multiple of the number of attention heads (24)`, matching the issue exactly; on this branch the same call now raises `ValueError: Only supports [...]` before any network access. Full `pytest -v tests/unit` (1345 passed) and `pytest tests/docs -v` (62 passed) on Python 3.11 and 3.13; `pre-commit run --all-files` (ruff, ruff-format, mypy strict, the generated-file `--check` hooks, codespell) clean on both changed source files.

### Test Configuration

- **Python version:** 3.11 and 3.13 (matrix extremes)
- **OS:** Linux (Docker, `python:3.11-slim` / `python:3.13-slim`)

## Checklist

- [x] Code is self-documenting with clear comments
- [x] Added type hints and docstrings
- [x] Updated documentation
- [x] No dead/debug code
- [x] No breaking changes (or documented if yes)

## Additional Notes

Did not independently re-verify `kanana-safeguard-8b` / `kanana-safeguard-siren-8b`, which the issue itself reports as unaffected; this PR only removes the broken third entry.
