### PR TITLE
fix(poly-guard): fail closed when the response harm verdict doesn't parse

### DIFF
--- a/docs/api/guardrails/poly-guard.md
+++ b/docs/api/guardrails/poly-guard.md
@@ -17,8 +17,8 @@ Verdict mapping onto ``GuardrailOutput``:
 - ``explanation`` is the raw generation.
 - ``usage`` carries the prompt / completion token counts. No canonical ``score`` or ``spans``
   are produced.
-- Fails closed (``valid=False`` with ``extra={"parse_failure": True}``) when neither
-  harmfulness field parses.
+- Fails closed (``valid=False`` with ``extra={"parse_failure": True}``) when either
+  harmfulness field fails to parse.
 
 Expected inputs: a single ``input_text`` string (the human request) plus an optional
 ``output_text`` string (the assistant response). The prompt template always carries both slots,

--- a/src/any_guardrail/guardrails/poly_guard/poly_guard.py
+++ b/src/any_guardrail/guardrails/poly_guard/poly_guard.py
@@ -75,8 +75,8 @@ class PolyGuard(ThreeStageGuardrail[PolyGuardPreprocessData, PolyGuardInferenceD
     - ``explanation`` is the raw generation.
     - ``usage`` carries the prompt / completion token counts. No canonical ``score`` or ``spans``
       are produced.
-    - Fails closed (``valid=False`` with ``extra={"parse_failure": True}``) when neither
-      harmfulness field parses.
+    - Fails closed (``valid=False`` with ``extra={"parse_failure": True}``) when either
+      harmfulness field fails to parse.
 
     Expected inputs: a single ``input_text`` string (the human request) plus an optional
     ``output_text`` string (the assistant response). The prompt template always carries both slots,
@@ -208,7 +208,7 @@ class PolyGuard(ThreeStageGuardrail[PolyGuardPreprocessData, PolyGuardInferenceD
         harmful_request = _field(_HARMFUL_REQUEST, text)
         response_refusal = _field(_RESPONSE_REFUSAL, text)
         harmful_response = _field(_HARMFUL_RESPONSE, text)
-        if harmful_request is None and harmful_response is None:
+        if harmful_request is None or harmful_response is None:
             return GuardrailOutput(valid=False, explanation=text, extra={"parse_failure": True})
         categories = [
             CategoryResult(name="harmful_request", triggered=harmful_request),

--- a/tests/unit/test_unit_new_guardrails.py
+++ b/tests/unit/test_unit_new_guardrails.py
@@ -96,6 +96,31 @@ def test_polyguard_fails_closed() -> None:
     assert result.extra == {"parse_failure": True}
 
 
+def test_polyguard_fails_closed_when_judged_response_verdict_missing() -> None:
+    instance = object.__new__(PolyGuard)
+    # Request verdict parses; the response-harm line is missing (e.g. truncated by
+    # MAX_NEW_TOKENS, since PolyGuard's prompt places "Harmful response" last). This must
+    # fail closed rather than silently report the unknown response as safe — mirrors
+    # test_wildguard_fails_closed_when_judged_response_verdict_missing above.
+    result = instance._post_processing(_gen("Harmful request: no\nResponse refusal: no"))
+    assert result.valid is False
+    assert result.extra == {"parse_failure": True}
+
+
+def test_polyguard_fully_parsed_harmful_response_is_invalid() -> None:
+    instance = object.__new__(PolyGuard)
+    text = "Harmful request: no\nResponse refusal: no\nHarmful response: yes"
+    result = instance._post_processing(_gen(text))
+    assert result.valid is False
+
+
+def test_polyguard_fully_parsed_benign_pair_is_valid() -> None:
+    instance = object.__new__(PolyGuard)
+    text = "Harmful request: no\nResponse refusal: no\nHarmful response: no"
+    result = instance._post_processing(_gen(text))
+    assert result.valid is True
+
+
 @pytest.mark.parametrize(
     ("text", "expected_valid"),
     [


### PR DESCRIPTION
## Description

PolyGuard silently reports a response as safe when its harmful-response verdict fails to parse. It only fails closed when *both* `harmful_request` and `harmful_response` are unparseable:

```python
if harmful_request is None and harmful_response is None:
    return GuardrailOutput(valid=False, explanation=text, extra={"parse_failure": True})
...
valid=not (bool(harmful_request) or bool(harmful_response)),
```

`src/any_guardrail/guardrails/poly_guard/poly_guard.py:211`

If the request verdict parses but the response verdict doesn't - truncated generation, `MAX_NEW_TOKENS=100` cutting off before "Harmful response:" (which the prompt places last), any malformed completion - `harmful_response` is `None`, `bool(None)` is `False`, and `valid` comes out `True` with `extra=None`. There's not even a `parse_failure` flag to signal that the response was never actually judged. A response whose harm status is unknown gets reported as safe.

WildGuard, added in the same PR (#183) by the same author with the same three regexes and prompt archetype, already gets this right:

```python
# Fail closed if the always-present request verdict is missing, or if a response was
# being judged but its harm verdict didn't parse (don't silently pass it as safe).
if harmful_request is None or (has_response and harmful_response is None):
```

`src/any_guardrail/guardrails/wild_guard/wild_guard.py:213-216`

WildGuard needs the `has_response` guard because it has a genuine no-response-judged case (`output_text=None` means only the request is judged). PolyGuard doesn't - I checked `_pre_processing` and it always fills both `{prompt}`/`{response}` template slots (`response=output_text or ""`), so a response is always judged, even if it's an empty string. A plain `or` is the correct minimal fix for PolyGuard; there's no case here that needs tolerating a missing response verdict.

The existing test coverage backs up that this is the intended convention and PolyGuard was just missed: `tests/unit/test_unit_new_guardrails.py` has `test_wildguard_fails_closed_when_judged_response_verdict_missing`, `test_nemotron_fails_closed_when_judged_response_verdict_missing`, and `test_qwen3guard_stream_fails_closed_on_missing_response_risk` - all guarding this exact scenario for their guardrail. There was no PolyGuard equivalent; the only existing PolyGuard fail-closed test (`test_polyguard_fails_closed`) passes garbage where *both* fields are missing, so it never exercised the partial-parse case.

Also fixed the docstring, which documented the buggy "when neither" behavior instead of "when either."

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

A guardrail that fails open on an unparseable verdict defeats the purpose of a guardrail - the one case where you most need `valid=False` is when you don't know the answer. This is a straightforward correctness/security fix, not a new issue filed first.

## Changes Made

- `poly_guard.py`: `harmful_request is None and harmful_response is None` -> `harmful_request is None or harmful_response is None` in `_post_processing`
- `poly_guard.py`: fixed docstring wording ("neither" -> "either")
- `tests/unit/test_unit_new_guardrails.py`: added `test_polyguard_fails_closed_when_judged_response_verdict_missing` (mirrors the existing WildGuard test of the same shape) plus two regression tests (`test_polyguard_fully_parsed_harmful_response_is_invalid`, `test_polyguard_fully_parsed_benign_pair_is_valid`)
- `docs/api/guardrails/poly-guard.md`: regenerated via `scripts/generate_api_docs.py` to pick up the docstring fix (only this file's diff kept; the rest of that script's output was unrelated environment churn and was discarded)

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

What I ran:

1. Added the new test against the unmodified (buggy) source - RED:
   ```
   test_polyguard_fails_closed_when_judged_response_verdict_missing FAILED
   AssertionError: assert True is False
   1 failed, 4 passed
   ```
2. Applied the one-line fix - GREEN:
   ```
   test_polyguard_fails_closed_when_judged_response_verdict_missing PASSED
   5 passed
   ```
3. Reverted the source fix only (kept the test) to confirm the test actually catches the regression - it failed the same way as step 1, then restored the fix.
4. Full unit suite: `python -m pytest tests/unit/ -q` -> `1347 passed in 17.84s`

### Test Configuration
- **Python version:** 3.14.7
- **OS:** macOS (darwin)

## Checklist

- [x] Code is self-documenting with clear comments
- [x] Added type hints and docstrings
- [x] Updated documentation
- [x] No dead/debug code
- [x] Robust error handling
- [x] No breaking changes (or documented if yes)
- [ ] Built on agreed direction from issue discussion (no issue filed - this is a small, obvious correctness fix with tests; happy to file an issue first if preferred)

## Performance Impact

- [x] No performance impact

## Breaking Changes

None. A caller that was relying on PolyGuard passing through a response with an unparseable verdict as `valid=True` was relying on the bug; the corrected behavior now matches WildGuard's already-documented and tested convention.

## Additional Notes

Scoped to PolyGuard only. `dyna_guard.py` has an identically-worded "when neither" docstring line, but I did not check whether its post-processing has the analogous logic bug - that's a separate guardrail with different parsing and out of scope for this PR.
