### PR TITLE
fix(deps): support gliner2 2.0 by declaring the deps it moved to an extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,16 @@ lettucedetect = [
 # Schema-driven safety/toxicity/jailbreak detection (GLiGuard guardrail).
 # NOTE: the MiniCheck guardrail has no extra — its library is git-only (not on PyPI),
 # so install it directly: pip install "minicheck @ git+https://github.com/Liyan06/MiniCheck.git"
+# gliner2 2.0.0 moved its local-inference dependencies (torch, transformers, peft,
+# safetensors, numpy) out of its core requirements into a new `local` extra, but
+# `gliner2/__init__.py` still imports them unconditionally — so a bare `pip install
+# gliner2` yields a package that cannot be imported at all. We declare those deps here
+# instead of using `gliner2[local]`, because that extra pins `transformers<5` and would
+# cap transformers for the whole project. GLiGuard runs fine on transformers 5.x.
 gliner = [
-  "gliner2"
+  "gliner2>=2",
+  "any-guardrail[huggingface]",
+  "peft>=0.10"
 ]
 
 huggingface = [

--- a/tests/unit/test_unit_special_guardrails.py
+++ b/tests/unit/test_unit_special_guardrails.py
@@ -1,5 +1,6 @@
 """Tests for the span / cross-encoder / library-wrapped guardrails and FlowJudge init paths."""
 
+import importlib.util
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -190,3 +191,41 @@ def test_flowjudge_accepts_prebuilt_metric() -> None:
 def test_flowjudge_requires_metric_or_convenience_fields() -> None:
     with patch.object(Flowjudge, "_load_model", return_value="model"), pytest.raises(ValueError, match="metric"):
         Flowjudge(name="only-name")
+
+
+# --- Guarded-import health for the library-wrapped guardrails -------------------
+#
+# These four modules wrap their upstream import in `try/except ImportError` and stash the
+# failure in MISSING_PACKAGES_ERROR, so `__init__` can re-raise a helpful pip hint. The
+# side effect is that a *broken* upstream release is swallowed at import time: the names
+# the module meant to bind are simply absent, and the first symptom is an unrelated-looking
+# AttributeError from whichever test patches one of them.
+#
+# That is exactly how gliner2 2.0.0 landed — it moved torch/transformers/peft/safetensors
+# into a new `local` extra while still importing them unconditionally, so the package
+# installed fine but could not be imported, and three GLiGuard tests failed with
+# "module ... does not have the attribute 'GLiNER2'" naming neither gliner2 nor peft.
+#
+# So distinguish the two cases. Package absent (a partial dev install) is fine and skips.
+# Package present but unimportable is a real problem, and the assertion names the cause.
+
+_GUARDED_IMPORTS = [
+    ("any_guardrail.guardrails.flowjudge.flowjudge", "flow_judge", "flowjudge"),
+    ("any_guardrail.guardrails.gli_guard.gli_guard", "gliner2", "gliner"),
+    ("any_guardrail.guardrails.gli_ner_pii.gli_ner_pii", "gliner2", "gliner"),
+    ("any_guardrail.guardrails.lettuce_detect.lettuce_detect", "lettucedetect", "lettucedetect"),
+]
+
+
+@pytest.mark.parametrize(("module_path", "package", "extra"), _GUARDED_IMPORTS, ids=lambda v: str(v).split(".")[-1])
+def test_installed_backend_actually_imports(module_path: str, package: str, extra: str) -> None:
+    """An installed optional backend must import; a broken release fails loudly, not silently."""
+    if importlib.util.find_spec(package) is None:
+        pytest.skip(f"{package} not installed (any-guardrail[{extra}])")
+    error = importlib.import_module(module_path).MISSING_PACKAGES_ERROR
+    assert error is None, (
+        f"{package} is installed but `import {package}` failed inside {module_path}, so the names it "
+        f"binds are missing and dependent tests will fail with a confusing AttributeError. "
+        f"This usually means the installed {package} release is broken or incompatible — check its "
+        f"declared dependencies and pin it in the [{extra}] extra. Underlying error: {error!r}"
+    )


### PR DESCRIPTION
## Description

`main` and every open PR went red on 2026-08-24 with three GLiGuard unit-test failures and no change on our side. Root cause is an upstream packaging change in `gliner2` 2.0.0, published that day at 15:13 UTC — the first failing run is at 15:42.

2.0.0 moved its local-inference dependencies (`torch`, `transformers`, `peft`, `safetensors`, `numpy`) out of its core requirements into a new `local` extra, but `gliner2/__init__.py` still imports them unconditionally. So a bare `pip install gliner2` now installs cleanly and cannot be imported at all:

```
>>> import gliner2
ModuleNotFoundError: No module named 'peft'
```

`gli_guard.py` and `gli_ner_pii.py` wrap that import in `try/except ImportError`, and `ModuleNotFoundError` subclasses `ImportError`, so the failure was swallowed and the module-level `GLiNER2` name never bound. The tests that patch it then failed with an error naming neither `gliner2` nor `peft`:

```
AttributeError: <module '...gli_guard'> does not have the attribute 'GLiNER2'
```

It hit immediately because `uv.lock` is gitignored (`.gitignore:1`), so CI resolves dependencies fresh from PyPI on every run.

## Approach: move forward to 2.0.0, don't cap it

The reflexive fix is `gliner2<2`. This PR deliberately doesn't do that — **GLiGuard works fine on gliner2 2.0.0**, so pinning backwards would give up a major release for no reason. What actually broke is only the dependency declaration, so this declares what upstream stopped declaring:

```toml
gliner = [
  "gliner2>=2",
  "any-guardrail[huggingface]",
  "peft>=0.10"
]
```

`gliner2[local]` would be the obvious way to express this and is **not** usable: that extra pins `transformers<5`, which would cap transformers for the entire project. We resolve 5.x today and GLiGuard is fine on it, so accepting that cap to satisfy a metadata declaration would be a real regression for an unreal problem.

A side benefit: `any-guardrail[gliner]` is self-sufficient again. Under 1.3.x, `torch` arrived transitively through the `gliner` package that 2.0.0 dropped, so installing the extra alone would otherwise now give an unimportable install.

## Also: make this class of failure legible

The incident cost was almost entirely diagnosis — the symptom named neither the package nor the missing dependency. Four modules share this guarded-import pattern (`flowjudge`, `gli_guard`, `gli_ner_pii`, `lettuce_detect`), so this adds one parametrized check across all of them that distinguishes the two cases:

- **package absent** (a partial dev install) → skip, as today
- **package present but unimportable** → fail, naming the real cause

Against the broken 2.0.0 it reports:

```
AssertionError: gliner2 is installed but `import gliner2` failed inside
any_guardrail.guardrails.gli_guard.gli_guard, so the names it binds are missing and
dependent tests will fail with a confusing AttributeError. This usually means the
installed gliner2 release is broken or incompatible — check its declared dependencies
and pin it in the [gliner] extra.
Underlying error: ModuleNotFoundError("No module named 'peft'")
```

## Testing

- **GLiGuard integration test passes against gliner2 2.0.0 on transformers 5.8.0** — real inference, not just import. This is the load-bearing check for choosing `>=2` over `<2`.
- New check verified both ways: red with `peft` uninstalled (reproducing CI's fresh resolve), green with it present.
- Reproduced the original failure first: bare `gliner2==2.0.0` fails on `torch`; with torch+transformers present it fails on `peft`.
- `pytest tests/unit` → 1352 passed (including the three previously failing GLiGuard tests).
- `pytest tests/docs` → 62 passed.
- `pre-commit run --all-files` → clean (ruff, ruff-format, mypy strict, codespell, all ten generated-file `--check` hooks).
- Confirmed the cap-based variant of this fix went green across all six CI jobs before I switched approaches, so the diagnosis is solid independent of which remedy lands.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Notes for reviewers

Two things deliberately left out of scope:

1. **The Unit Tests workflow doesn't run on dependency changes.** Its `paths` filter is `src/**` + `tests/**`, so a `pyproject.toml`-only change gets no unit-test signal — the workflow this PR repairs wouldn't have run on it. This PR happens to touch `tests/**` so it does run now, but that's incidental. Adding `pyproject.toml` to the filter seems worth doing separately.
2. **`mypy @ git+https://github.com/python/mypy.git` is unpinned** (`pyproject.toml:234`), so every run builds whatever `master` currently is — an independent source of unrelated CI failures.
